### PR TITLE
Harden L@tr gateway OAuth and DPoP verification

### DIFF
--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Hummingbird
 import HTTPTypes
+import AsyncHTTPClient
 
 public struct AuthContext: Sendable {
     public let did: String
@@ -87,6 +88,7 @@ public func authenticateRequest(
     _ request: Request,
     config: GatewayConfig,
     store: any DeveloperStore,
+    httpClient: HTTPClient? = nil,
     requireClientAPIKey override: Bool? = nil
 ) async throws -> AuthContext {
     let requireRegisteredClient = resolvesRegisteredClientRequirement(
@@ -116,9 +118,24 @@ public func authenticateRequest(
     guard let dpop = extractDPOPHeader(from: request.headers) else {
         throw GatewayError(status: .unauthorized, message: "Missing DPoP proof header", code: "missing_dpop")
     }
-    try assertDPOPStructure(dpop)
+    let dpopJWK = try verifyGatewayDPoP(proof: dpop, accessToken: accessToken, request: request)
 
-    let payload = try decodeJWTPayload(accessToken)
+    let payload: JWTPayload
+    if let httpClient {
+        payload = try await OAuthTokenVerifier(httpClient: httpClient)
+            .verify(accessToken: accessToken, dpopJWK: dpopJWK)
+            .payload
+    } else {
+        payload = try decodeJWTPayload(accessToken)
+        if let jkt = payload.cnf?.jkt {
+            guard try jkt == jwkThumbprint(dpopJWK) else {
+                throw GatewayError(status: .unauthorized, message: "Token DPoP key mismatch", code: "invalid_token")
+            }
+        } else {
+            throw GatewayError(status: .unauthorized, message: "Token missing DPoP confirmation", code: "invalid_token")
+        }
+    }
+
     guard let did = payload.sub?.trimmingCharacters(in: .whitespacesAndNewlines), did.hasPrefix("did:") else {
         throw GatewayError(status: .unauthorized, message: "Access token sub must be a DID", code: "invalid_sub")
     }

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
@@ -1,0 +1,143 @@
+import Crypto
+import Foundation
+import Hummingbird
+import HTTPTypes
+
+struct DPoPJWK: Decodable, Encodable {
+    let kty: String
+    let crv: String
+    let x: String
+    let y: String
+}
+
+private struct DPoPHeader: Decodable {
+    let typ: String?
+    let alg: String
+    let jwk: DPoPJWK
+}
+
+private struct DPoPPayload: Decodable {
+    let htm: String
+    let htu: String
+    let iat: Int
+    let jti: String
+    let ath: String?
+}
+
+private final class DPoPReplayCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen: [String: Int] = [:]
+
+    func insert(_ jti: String, expiresAt: Int, now: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        seen = seen.filter { $0.value >= now }
+        guard seen[jti] == nil else { return false }
+        seen[jti] = expiresAt
+        return true
+    }
+}
+
+private let dpopReplayCache = DPoPReplayCache()
+
+func verifyGatewayDPoP(
+    proof: String,
+    accessToken: String,
+    request: Request,
+    now: Date = Date()
+) throws -> DPoPJWK {
+    let headerData = try jwtSegmentData(proof, segment: 0, code: "invalid_dpop")
+    let payloadData = try jwtSegmentData(proof, segment: 1, code: "invalid_dpop")
+    let header = try decodeDPoP(DPoPHeader.self, from: headerData)
+    let payload = try decodeDPoP(DPoPPayload.self, from: payloadData)
+
+    guard header.typ?.caseInsensitiveCompare("dpop+jwt") == .orderedSame else {
+        throw GatewayError(status: .unauthorized, message: "Invalid DPoP proof type", code: "invalid_dpop")
+    }
+    guard header.alg == "ES256", header.jwk.kty == "EC", header.jwk.crv == "P-256" else {
+        throw GatewayError(status: .unauthorized, message: "Unsupported DPoP key", code: "invalid_dpop")
+    }
+
+    guard payload.htm.uppercased() == request.method.rawValue.uppercased() else {
+        throw GatewayError(status: .unauthorized, message: "DPoP method mismatch", code: "invalid_dpop")
+    }
+    guard normalizeDPoPURL(payload.htu) == normalizeDPoPURL(gatewayRequestURL(request)) else {
+        throw GatewayError(status: .unauthorized, message: "DPoP URL mismatch", code: "invalid_dpop")
+    }
+
+    let nowSeconds = Int(now.timeIntervalSince1970)
+    guard abs(nowSeconds - payload.iat) <= 300 else {
+        throw GatewayError(status: .unauthorized, message: "DPoP proof expired", code: "invalid_dpop")
+    }
+    guard !payload.jti.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+          dpopReplayCache.insert(payload.jti, expiresAt: payload.iat + 300, now: nowSeconds)
+    else {
+        throw GatewayError(status: .unauthorized, message: "DPoP proof replayed", code: "invalid_dpop_replay")
+    }
+
+    let expectedAth = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
+    guard payload.ath == expectedAth else {
+        throw GatewayError(status: .unauthorized, message: "DPoP access token hash mismatch", code: "invalid_dpop")
+    }
+
+    let publicKey = try publicKey(from: header.jwk)
+    let signature = try P256.Signing.ECDSASignature(rawRepresentation: jwtSignature(proof))
+    guard publicKey.isValidSignature(signature, for: try jwtSigningInput(proof)) else {
+        throw GatewayError(status: .unauthorized, message: "Invalid DPoP signature", code: "invalid_dpop")
+    }
+
+    return header.jwk
+}
+
+func jwkThumbprint(_ jwk: DPoPJWK) throws -> String {
+    let canonical = #"{"crv":"\#(jwk.crv)","kty":"\#(jwk.kty)","x":"\#(jwk.x)","y":"\#(jwk.y)"}"#
+    return base64URLEncode(Data(SHA256.hash(data: Data(canonical.utf8))))
+}
+
+private func publicKey(from jwk: DPoPJWK) throws -> P256.Signing.PublicKey {
+    guard let x = base64URLDecode(jwk.x), let y = base64URLDecode(jwk.y), x.count == 32, y.count == 32 else {
+        throw GatewayError(status: .unauthorized, message: "Invalid DPoP public key", code: "invalid_dpop")
+    }
+    return try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+}
+
+private func jwtSegmentData(_ jwt: String, segment: Int, code: String) throws -> Data {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, parts.indices.contains(segment), let data = base64URLDecode(String(parts[segment])) else {
+        throw GatewayError(status: .unauthorized, message: "Malformed DPoP proof", code: code)
+    }
+    return data
+}
+
+private func decodeDPoP<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    do {
+        return try JSONDecoder().decode(T.self, from: data)
+    } catch {
+        throw GatewayError(status: .unauthorized, message: "Malformed DPoP proof", code: "invalid_dpop")
+    }
+}
+
+private func gatewayRequestURL(_ request: Request) -> String {
+    if request.uri.description.hasPrefix("http://") || request.uri.description.hasPrefix("https://") {
+        return request.uri.description
+    }
+    let scheme = request.head.scheme ?? "http"
+    let authority = request.head.authority ?? "localhost"
+    return "\(scheme)://\(authority)\(request.uri)"
+}
+
+private func normalizeDPoPURL(_ raw: String) -> String? {
+    guard var components = URLComponents(string: raw),
+          let scheme = components.scheme?.lowercased(),
+          let host = components.host?.lowercased()
+    else {
+        return nil
+    }
+    components.scheme = scheme
+    components.host = host
+    components.fragment = nil
+    if (scheme == "https" && components.port == 443) || (scheme == "http" && components.port == 80) {
+        components.port = nil
+    }
+    return components.url?.absoluteString
+}

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTPayload.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTPayload.swift
@@ -2,10 +2,16 @@ import Foundation
 
 struct JWTPayload: Decodable {
     let sub: String?
+    let iss: String?
     let exp: Int?
     let client_id: String?
     let azp: String?
     let aud: Audience?
+    let cnf: Confirmation?
+
+    struct Confirmation: Decodable {
+        let jkt: String?
+    }
 
     enum Audience: Decodable {
         case single(String)
@@ -31,17 +37,11 @@ struct JWTPayload: Decodable {
 
 func decodeJWTPayload(_ token: String) throws -> JWTPayload {
     let parts = token.split(separator: ".", omittingEmptySubsequences: false)
-    guard parts.count >= 2 else {
+    guard parts.count == 3 else {
         throw GatewayError(status: .unauthorized, message: "Malformed access token", code: "invalid_token")
     }
 
-    var payloadB64 = String(parts[1])
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    let padding = (4 - payloadB64.count % 4) % 4
-    payloadB64.append(String(repeating: "=", count: padding))
-
-    guard let data = Data(base64Encoded: payloadB64) else {
+    guard let data = base64URLDecode(String(parts[1])) else {
         throw GatewayError(
             status: .unauthorized,
             message: "Malformed access token payload",

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTUtilities.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTUtilities.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+func base64URLDecode(_ value: String) -> Data? {
+    var base64 = value
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    let padding = (4 - base64.count % 4) % 4
+    base64.append(String(repeating: "=", count: padding))
+    return Data(base64Encoded: base64)
+}
+
+func base64URLEncode(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+func decodeJWTJSON(_ jwt: String, segment: Int) throws -> [String: Any] {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, parts.indices.contains(segment) else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT", code: "invalid_token")
+    }
+    guard let data = base64URLDecode(String(parts[segment])),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT payload", code: "invalid_token")
+    }
+    return json
+}
+
+func jwtSigningInput(_ jwt: String) throws -> Data {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3 else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT", code: "invalid_token")
+    }
+    return Data("\(parts[0]).\(parts[1])".utf8)
+}
+
+func jwtSignature(_ jwt: String) throws -> Data {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, let signature = base64URLDecode(String(parts[2])) else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT signature", code: "invalid_token")
+    }
+    return signature
+}
+
+func jwtClaimString(_ jwt: String, claim: String) -> String? {
+    guard let json = try? decodeJWTJSON(jwt, segment: 1) else { return nil }
+    return json[claim] as? String
+}

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
@@ -1,0 +1,153 @@
+import AsyncHTTPClient
+import Crypto
+import Foundation
+
+private struct OAuthTokenHeader: Decodable {
+    let alg: String
+    let kid: String?
+}
+
+private struct OAuthAuthorizationServerMetadata: Decodable {
+    let issuer: String?
+    let jwks_uri: String
+}
+
+private struct JWKSet: Decodable {
+    let keys: [OAuthJWK]
+}
+
+private struct OAuthJWK: Decodable {
+    let kty: String
+    let kid: String?
+    let crv: String?
+    let x: String?
+    let y: String?
+    let n: String?
+    let e: String?
+}
+
+struct VerifiedOAuthToken: Sendable {
+    let payload: JWTPayload
+}
+
+public struct OAuthTokenVerifier: Sendable {
+    private let httpClient: HTTPClient
+    private let fetchData: (@Sendable (URL) async throws -> Data)?
+
+    public init(
+        httpClient: HTTPClient,
+        fetchData: (@Sendable (URL) async throws -> Data)? = nil
+    ) {
+        self.httpClient = httpClient
+        self.fetchData = fetchData
+    }
+
+    func verify(accessToken: String, dpopJWK: DPoPJWK) async throws -> VerifiedOAuthToken {
+        let header = try decodeJWTHeader(accessToken)
+        let payload = try decodeJWTPayload(accessToken)
+        guard let issuer = payload.iss?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let issuerURL = URL(string: issuer),
+              issuerURL.scheme == "https",
+              issuerURL.host?.isEmpty == false
+        else {
+            throw GatewayError(status: .unauthorized, message: "Missing token issuer", code: "invalid_token")
+        }
+
+        let metadata = try await fetchAuthorizationServerMetadata(issuerURL: issuerURL)
+        if let metadataIssuer = metadata.issuer, metadataIssuer != issuer {
+            throw GatewayError(status: .unauthorized, message: "Token issuer metadata mismatch", code: "invalid_token")
+        }
+        let jwks = try await fetchJWKSet(jwksURI: metadata.jwks_uri)
+        guard let key = jwks.keys.first(where: { jwk in
+            guard jwk.kty == keyType(for: header.alg) else { return false }
+            guard let kid = header.kid else { return true }
+            return jwk.kid == kid
+        }) else {
+            throw GatewayError(status: .unauthorized, message: "Token signing key not found", code: "invalid_token")
+        }
+
+        guard try verifyJWTSignature(jwt: accessToken, header: header, key: key) else {
+            throw GatewayError(status: .unauthorized, message: "Invalid token signature", code: "invalid_token")
+        }
+
+        if let cnf = payload.cnf, let jkt = cnf.jkt {
+            guard try jkt == jwkThumbprint(dpopJWK) else {
+                throw GatewayError(status: .unauthorized, message: "Token DPoP key mismatch", code: "invalid_token")
+            }
+        } else {
+            throw GatewayError(status: .unauthorized, message: "Token missing DPoP confirmation", code: "invalid_token")
+        }
+
+        return VerifiedOAuthToken(payload: payload)
+    }
+
+    private func decodeJWTHeader(_ token: String) throws -> OAuthTokenHeader {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let data = base64URLDecode(String(parts[0]))
+        else {
+            throw GatewayError(status: .unauthorized, message: "Malformed access token", code: "invalid_token")
+        }
+        do {
+            return try JSONDecoder().decode(OAuthTokenHeader.self, from: data)
+        } catch {
+            throw GatewayError(status: .unauthorized, message: "Malformed access token header", code: "invalid_token")
+        }
+    }
+
+    private func fetchAuthorizationServerMetadata(issuerURL: URL) async throws -> OAuthAuthorizationServerMetadata {
+        let metadataURL = issuerURL.appendingPathComponent(".well-known/oauth-authorization-server")
+        let data = try await fetch(metadataURL)
+        return try JSONDecoder().decode(OAuthAuthorizationServerMetadata.self, from: data)
+    }
+
+    private func fetchJWKSet(jwksURI: String) async throws -> JWKSet {
+        guard let url = URL(string: jwksURI), url.scheme == "https", url.host?.isEmpty == false else {
+            throw GatewayError(status: .unauthorized, message: "Invalid token JWKS URI", code: "invalid_token")
+        }
+        let data = try await fetch(url)
+        return try JSONDecoder().decode(JWKSet.self, from: data)
+    }
+
+    private func fetch(_ url: URL) async throws -> Data {
+        if let fetchData {
+            return try await fetchData(url)
+        }
+        var request = HTTPClientRequest(url: url.absoluteString)
+        request.headers.add(name: "Accept", value: "application/json")
+        let response = try await httpClient.execute(request, timeout: .seconds(10))
+        guard response.status == .ok else {
+            throw GatewayError(status: .unauthorized, message: "Token metadata lookup failed", code: "invalid_token")
+        }
+        let body = try await response.body.collect(upTo: 1_048_576)
+        return Data(buffer: body)
+    }
+
+    private func verifyJWTSignature(jwt: String, header: OAuthTokenHeader, key: OAuthJWK) throws -> Bool {
+        let signingInput = try jwtSigningInput(jwt)
+        let signature = try jwtSignature(jwt)
+        switch header.alg {
+        case "ES256":
+            guard key.crv == "P-256",
+                  let x = key.x.flatMap(base64URLDecode),
+                  let y = key.y.flatMap(base64URLDecode),
+                  x.count == 32,
+                  y.count == 32
+            else {
+                return false
+            }
+            let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+            let ecdsa = try P256.Signing.ECDSASignature(rawRepresentation: signature)
+            return publicKey.isValidSignature(ecdsa, for: signingInput)
+        default:
+            return false
+        }
+    }
+
+    private func keyType(for alg: String) -> String {
+        switch alg {
+        case "ES256": "EC"
+        default: ""
+        }
+    }
+}

--- a/services/latr-gateway/Sources/LatrGatewayLib/Developer/DeveloperRoutes.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Developer/DeveloperRoutes.swift
@@ -1,3 +1,4 @@
+import AsyncHTTPClient
 import Foundation
 import Hummingbird
 
@@ -127,7 +128,12 @@ private func handleDeveloper(
     handler: (AuthContext) async throws -> Response
 ) async -> Response {
     do {
-        let auth = try await authenticateDeveloperRequest(request, config: services.config, store: services.developerStore)
+        let auth = try await authenticateDeveloperRequest(
+            request,
+            config: services.config,
+            store: services.developerStore,
+            httpClient: services.httpClient
+        )
         return try await handler(auth)
     } catch {
         return errorResponse(error)
@@ -137,12 +143,14 @@ private func handleDeveloper(
 private func authenticateDeveloperRequest(
     _ request: Request,
     config: GatewayConfig,
-    store: any DeveloperStore
+    store: any DeveloperStore,
+    httpClient: HTTPClient
 ) async throws -> AuthContext {
     try await authenticateRequest(
         request,
         config: config,
         store: store,
+        httpClient: httpClient,
         requireClientAPIKey: false
     )
 }

--- a/services/latr-gateway/Sources/LatrGatewayLib/PDS/PDSRepoClient.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/PDS/PDSRepoClient.swift
@@ -77,12 +77,12 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
         let requestURL: String
         let dpopProof: String
         let usedUpstreamProof: Bool
-        if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "POST") {
+        let base = try await pdsBase()
+        if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "POST", pdsBase: base) {
             requestURL = consumed.url
             dpopProof = consumed.proof
             usedUpstreamProof = true
         } else {
-            let base = try await pdsBase()
             requestURL = "\(base)/xrpc/\(method)"
             dpopProof = auth.dpopProof
             usedUpstreamProof = false
@@ -151,17 +151,16 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
     private func xrpcGet(method: String, query: [String: String], useAuth: Bool) async throws -> [String: Any] {
         let xrpcBaseURL: String
         let dpopProof: String?
+        let base = try await pdsBase()
         if useAuth {
-            if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "GET") {
+            if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "GET", pdsBase: base) {
                 xrpcBaseURL = consumed.url
                 dpopProof = consumed.proof
             } else {
-                let base = try await pdsBase()
                 xrpcBaseURL = "\(base)/xrpc/\(method)"
                 dpopProof = auth.dpopProof
             }
         } else {
-            let base = try await pdsBase()
             xrpcBaseURL = "\(base)/xrpc/\(method)"
             dpopProof = nil
         }
@@ -348,4 +347,3 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
         )
     }
 }
-

--- a/services/latr-gateway/Sources/LatrGatewayLib/PDS/UpstreamProofPool.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/PDS/UpstreamProofPool.swift
@@ -15,10 +15,11 @@ final class UpstreamProofPool: @unchecked Sendable {
         }
     }
 
-    func consume(forXrpcMethod method: String, httpMethod: String) -> (proof: String, url: String)? {
+    func consume(forXrpcMethod method: String, httpMethod: String, pdsBase: String) -> (proof: String, url: String)? {
         lock.lock()
         defer { lock.unlock() }
 
+        let normalizedPDSBase = pdsBase.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         for (index, proof) in proofs.enumerated() {
             guard let htu = decodeJWTClaimString(proof, claim: "htu"),
                   let htm = decodeJWTClaimString(proof, claim: "htm"),
@@ -28,6 +29,7 @@ final class UpstreamProofPool: @unchecked Sendable {
             }
 
             let normalized = htu.split(separator: "?").first.map(String.init) ?? htu
+            guard normalized.hasPrefix("\(normalizedPDSBase)/xrpc/") else { continue }
             guard normalized.hasSuffix("/xrpc/\(method)") else { continue }
 
             proofs.remove(at: index)
@@ -39,16 +41,7 @@ final class UpstreamProofPool: @unchecked Sendable {
 }
 
 private func decodeJWTClaimString(_ jwt: String, claim: String) -> String? {
-    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
-    guard parts.count >= 2 else { return nil }
-
-    var payloadB64 = String(parts[1])
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    let padding = (4 - payloadB64.count % 4) % 4
-    payloadB64.append(String(repeating: "=", count: padding))
-
-    guard let data = Data(base64Encoded: payloadB64),
+    guard let data = base64URLDecode(String(jwt.split(separator: ".", omittingEmptySubsequences: false).dropFirst().first ?? "")),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
           let value = json[claim] as? String
     else {

--- a/services/latr-gateway/Sources/LatrGatewayLib/Routes/AppRouter.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Routes/AppRouter.swift
@@ -260,7 +260,8 @@ private func handleProtected(
         let auth = try await authenticateRequest(
             request,
             config: services.config,
-            store: services.developerStore
+            store: services.developerStore,
+            httpClient: services.httpClient
         )
         if let clientID = auth.clientID {
             try await services.developerStore.assertWithinDailyLimit(clientID: clientID)

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -1,0 +1,135 @@
+import AsyncHTTPClient
+import Crypto
+import Foundation
+import Hummingbird
+@testable import LatrGatewayLib
+import NIOCore
+import XCTest
+
+final class AuthVerificationTests: XCTestCase {
+    func testDPoPRejectsUnsignedProofThatUsedToPassStructureCheck() throws {
+        let token = unsignedAccessToken()
+        let proof = unsignedProof(
+            htm: "GET",
+            htu: "https://api.testing.latr.link/v1/latr/saves",
+            accessToken: token
+        )
+
+        XCTAssertThrowsError(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(path: "/v1/latr/saves")
+            )
+        )
+    }
+
+    func testDPoPRejectsWrongRequestBinding() throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let proof = try signedDPoP(
+            signingKey: key,
+            jwk: jwk,
+            htm: "POST",
+            htu: "https://api.testing.latr.link/v1/latr/saves",
+            accessToken: token
+        )
+
+        XCTAssertThrowsError(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(path: "/v1/latr/saves")
+            )
+        )
+    }
+
+    func testOAuthVerifierRejectsTamperedAccessTokenSignature() async throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let tampered = "\(token)a"
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","crv":"P-256","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
+            _ = try await verifier.verify(accessToken: tampered, dpopJWK: jwk)
+            XCTFail("tampered token should fail verification")
+        } catch {}
+        try await httpClient.shutdown()
+    }
+
+    private func request(path: String) -> Request {
+        Request(
+            head: HTTPRequest(
+                method: .get,
+                scheme: "https",
+                authority: "api.testing.latr.link",
+                path: path
+            ),
+            body: RequestBody(buffer: ByteBuffer())
+        )
+    }
+
+    private func unsignedAccessToken() -> String {
+        let header = #"{"alg":"none"}"#
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"test"}}"#
+        return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
+    }
+
+    private func unsignedProof(htm: String, htu: String, accessToken: String) -> String {
+        let header = #"{"typ":"dpop+jwt","alg":"none","jwk":{"kty":"EC","crv":"P-256","x":"test","y":"test"}}"#
+        let ath = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
+        let payload = #"{"htm":"\#(htm)","htu":"\#(htu)","iat":1782860400,"jti":"unsigned-proof","ath":"\#(ath)"}"#
+        return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
+    }
+
+    private func signedAccessToken(signingKey: P256.Signing.PrivateKey, dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"alg":"ES256","kid":"test-key"}"#
+        let jkt = try jwkThumbprint(dpopJWK)
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func signedDPoP(
+        signingKey: P256.Signing.PrivateKey,
+        jwk: DPoPJWK,
+        htm: String,
+        htu: String,
+        accessToken: String
+    ) throws -> String {
+        let header = #"{"typ":"dpop+jwt","alg":"ES256","jwk":{"kty":"EC","crv":"P-256","x":"\#(jwk.x)","y":"\#(jwk.y)"}}"#
+        let ath = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
+        let payload = #"{"htm":"\#(htm)","htu":"\#(htu)","iat":1782860400,"jti":"\#(UUID().uuidString)","ath":"\#(ath)"}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func signJWT(header: String, payload: String, signingKey: P256.Signing.PrivateKey) throws -> String {
+        let signingInput = "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8)))"
+        let signature = try signingKey.signature(for: Data(signingInput.utf8)).rawRepresentation
+        return "\(signingInput).\(base64URLEncode(signature))"
+    }
+
+    private func jwk(for publicKey: P256.Signing.PublicKey) -> DPoPJWK {
+        let raw = publicKey.x963Representation
+        return DPoPJWK(
+            kty: "EC",
+            crv: "P-256",
+            x: base64URLEncode(raw.dropFirst().prefix(32)),
+            y: base64URLEncode(raw.dropFirst(33).prefix(32))
+        )
+    }
+}

--- a/services/latr-gateway/Tests/LatrGatewayTests/UpstreamProofPoolTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/UpstreamProofPoolTests.swift
@@ -14,7 +14,8 @@ final class UpstreamProofPoolTests: XCTestCase {
 
         let first = pool.consume(
             forXrpcMethod: "com.atproto.repo.createRecord",
-            httpMethod: "POST"
+            httpMethod: "POST",
+            pdsBase: "https://pds.example"
         )
         XCTAssertEqual(first?.proof, createOne)
         XCTAssertEqual(
@@ -24,20 +25,37 @@ final class UpstreamProofPoolTests: XCTestCase {
 
         let second = pool.consume(
             forXrpcMethod: "com.atproto.repo.createRecord",
-            httpMethod: "POST"
+            httpMethod: "POST",
+            pdsBase: "https://pds.example"
         )
         XCTAssertEqual(second?.proof, createTwo)
 
         let third = pool.consume(
             forXrpcMethod: "com.atproto.repo.putRecord",
-            httpMethod: "POST"
+            httpMethod: "POST",
+            pdsBase: "https://pds.example"
         )
         XCTAssertEqual(third?.proof, putProof)
 
         XCTAssertNil(
             pool.consume(
                 forXrpcMethod: "com.atproto.repo.createRecord",
-                httpMethod: "POST"
+                httpMethod: "POST",
+                pdsBase: "https://pds.example"
+            )
+        )
+    }
+
+    func testRejectsMatchingMethodOnDifferentPDSOrigin() {
+        let proof =
+            "eyJhbGciOiJub25lIn0.eyJodHUiOiJodHRwczovL2F0dGFja2VyLmV4YW1wbGUveHJwYy9jb20uYXRwcm90by5yZXBvLmNyZWF0ZVJlY29yZCIsImh0bSI6IlBPU1QifQ.signature"
+        let pool = UpstreamProofPool(rawHeader: proof)
+
+        XCTAssertNil(
+            pool.consume(
+                forXrpcMethod: "com.atproto.repo.createRecord",
+                httpMethod: "POST",
+                pdsBase: "https://pds.example"
             )
         )
     }


### PR DESCRIPTION
## Summary
- Tighten OAuth client metadata handling and DPoP verification across the gateway, web app, and extension flows
- Align auth/scopes, callback routing, and gateway URL handling with the current hosted and local environments
- Update shared client packages, docs, and fixtures to keep web and extension behavior consistent
- Refresh CI and app assets/config so the new auth flow ships with matching metadata and icons

## Testing
- Added and updated unit tests for OAuth metadata, auth config, gateway URL resolution, and save/resolve helpers
- Ran the relevant app and package test suites and smoke checks locally; results were green