### PR TITLE
Fix DPoP scheme handling across gateway auth and client tests

### DIFF
--- a/apps/web/src/lib/latrRepo.test.ts
+++ b/apps/web/src/lib/latrRepo.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 import { configureLatrGateway } from "latr-web-client/latrGatewayConfig";
 import { LatrRepo } from "latr-web-client/latrRepo";
+
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   configureLatrGateway({
@@ -12,6 +14,10 @@ beforeEach(() => {
     clientId: "",
     apiKey: "",
   });
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
 });
 
 function mockOAuthSession(
@@ -49,9 +55,9 @@ function mockOAuthSession(
 describe("Latrrepo Gateway Facade", () => {
   test("listSavedItems migrates legacy lexicons then reads saved items", async () => {
     const calls: string[] = [];
-    const oauth = mockOAuthSession(async (url, init) => {
+    globalThis.fetch = (async (url, init) => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
-      if (url.includes("/v1/latr/migrate-lexicons")) {
+      if (String(url).includes("/v1/latr/migrate-lexicons")) {
         return new Response(
           JSON.stringify({
             ok: true,
@@ -80,6 +86,12 @@ describe("Latrrepo Gateway Facade", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -103,7 +115,7 @@ describe("Latrrepo Gateway Facade", () => {
 
   test("saveExternalUrl POSTs URL Body", async () => {
     let body = "";
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       body = String(init?.body ?? "");
       return new Response(
         JSON.stringify({ ok: true, kind: "url", storage: "external" }),
@@ -112,6 +124,12 @@ describe("Latrrepo Gateway Facade", () => {
         headers: { "Content-Type": "application/json" },
       }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -124,11 +142,17 @@ describe("Latrrepo Gateway Facade", () => {
 
   test("setItemState PATCHes State Route", async () => {
     let path = "";
-    const oauth = mockOAuthSession(async (url) => {
-      path = url;
+    globalThis.fetch = (async (url) => {
+      path = String(url);
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 
@@ -139,11 +163,17 @@ describe("Latrrepo Gateway Facade", () => {
 
   test("Unsave Deletes Item Route", async () => {
     let method = "";
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       method = init?.method ?? "";
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 

--- a/packages/latr-web-client/package.json
+++ b/packages/latr-web-client/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@atproto/api": "^0.19.17",
     "@atproto/oauth-client-browser": "^0.3.42",
-    "@atproto/syntax": "^0.5.0",
-    "latr-packages": "github:Stygian-Tech/latr-packages#072eddc"
+    "@atproto/syntax": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.4",

--- a/packages/latr-web-client/src/latrGatewayClient.test.ts
+++ b/packages/latr-web-client/src/latrGatewayClient.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 import {
   LATR_GATEWAY_MIGRATE_LEXICONS_PATH,
@@ -7,6 +7,8 @@ import {
 
 import { configureLatrGateway } from "./latrGatewayConfig";
 import { latrGatewayFetch } from "./latrGatewayClient";
+
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   configureLatrGateway({
@@ -19,8 +21,13 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
 function mockOAuthSession(
-  handler: (url: string, init?: RequestInit) => Promise<Response>
+  handler: (url: string, init?: RequestInit) => Promise<Response>,
+  onJwtClaims?: (claims: Record<string, string | number>) => void
 ): OAuthSession {
   let proofCount = 0;
 
@@ -44,8 +51,9 @@ function mockOAuthSession(
       dpopKey: {
         bareJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
         algorithms: ["ES256"],
-        createJwt: async () => {
+        createJwt: async (_header: unknown, claims: Record<string, string | number>) => {
           proofCount += 1;
+          onJwtClaims?.(claims);
           return `proof-${proofCount}`;
         },
       },
@@ -60,13 +68,20 @@ describe("latrGatewayFetch upstream proofs", () => {
   test("GET /v1/latr/saves sends list-only upstream proofs", async () => {
     let upstreamHeader = "";
 
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       upstreamHeader = String(
         new Headers(init?.headers).get(LATR_UPSTREAM_DPOP_HEADER) ?? ""
       );
       return new Response(JSON.stringify({ records: [] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 
@@ -78,7 +93,7 @@ describe("latrGatewayFetch upstream proofs", () => {
   test("POST /v1/latr/migrate-lexicons sends migration upstream proofs", async () => {
     let upstreamHeader = "";
 
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       upstreamHeader = String(
         new Headers(init?.headers).get(LATR_UPSTREAM_DPOP_HEADER) ?? ""
       );
@@ -95,6 +110,13 @@ describe("latrGatewayFetch upstream proofs", () => {
           headers: { "Content-Type": "application/json" },
         }
       );
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     await latrGatewayFetch(oauth, LATR_GATEWAY_MIGRATE_LEXICONS_PATH, {
@@ -107,13 +129,20 @@ describe("latrGatewayFetch upstream proofs", () => {
   test("POST /v1/latr/saves sends save upstream proofs", async () => {
     let upstreamHeader = "";
 
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       upstreamHeader = String(
         new Headers(init?.headers).get(LATR_UPSTREAM_DPOP_HEADER) ?? ""
       );
       return new Response(JSON.stringify({ ok: true, kind: "url" }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 
@@ -124,5 +153,41 @@ describe("latrGatewayFetch upstream proofs", () => {
     });
 
     expect(upstreamHeader.split(",")).toHaveLength(8);
+  });
+
+  test("sends explicit gateway Authorization and DPoP headers", async () => {
+    let authorization = "";
+    let dpop = "";
+    const claimsSeen: Record<string, string | number>[] = [];
+
+    globalThis.fetch = (async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      authorization = headers.get("Authorization") ?? "";
+      dpop = headers.get("DPoP") ?? "";
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(
+      async () =>
+        new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+          status: 400,
+          headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+        }),
+      (claims) => claimsSeen.push(claims)
+    );
+
+    await latrGatewayFetch(oauth, "/v1/latr/og-preview?url=https://example.com", {
+      method: "GET",
+    });
+
+    expect(authorization).toBe("DPoP test-access-token");
+    expect(dpop).toBe("proof-1");
+    expect(claimsSeen[0]).toMatchObject({
+      htm: "GET",
+      htu: "http://127.0.0.1:8080/v1/latr/og-preview",
+    });
   });
 });

--- a/packages/latr-web-client/src/latrGatewayClient.ts
+++ b/packages/latr-web-client/src/latrGatewayClient.ts
@@ -25,6 +25,72 @@ export type LatrGatewayFetchOptions = {
   skipClientCredential?: boolean;
 };
 
+type TokenSet = {
+  access_token: string;
+  token_type?: string;
+};
+
+type SessionWithTokenSet = OAuthSession & {
+  getTokenSet(refresh: boolean | "auto"): Promise<TokenSet>;
+};
+
+function stripQueryAndFragment(url: string): string {
+  const fragmentIndex = url.indexOf("#");
+  const queryIndex = url.indexOf("?");
+  if (fragmentIndex === -1 && queryIndex === -1) return url;
+  if (fragmentIndex === -1) return url.slice(0, queryIndex);
+  if (queryIndex === -1) return url.slice(0, fragmentIndex);
+  return url.slice(0, Math.min(fragmentIndex, queryIndex));
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(digest);
+  let binary = "";
+  for (const byte of view) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function buildGatewayUserAuthHeaders(
+  oauthSession: OAuthSession,
+  method: string,
+  gatewayUrl: string,
+  tokenSet: TokenSet
+): Promise<Record<string, string>> {
+  const key = oauthSession.server.dpopKey;
+  const jwk = key.bareJwk;
+  if (!jwk) {
+    throw new Error("OAuth session DPoP key is unavailable");
+  }
+
+  const supported =
+    oauthSession.server.serverMetadata.dpop_signing_alg_values_supported;
+  const alg =
+    supported?.find((candidate) => key.algorithms.includes(candidate)) ??
+    key.algorithms[0];
+  if (!alg) {
+    throw new Error("OAuth session DPoP key has no supported algorithm");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const claims: Record<string, string | number> = {
+    iat: now,
+    jti: Math.random().toString(36).slice(2),
+    htm: method.toUpperCase(),
+    htu: stripQueryAndFragment(gatewayUrl),
+    ath: await sha256Base64Url(tokenSet.access_token),
+  };
+  const dpop = await key.createJwt({ alg, typ: "dpop+jwt", jwk }, claims);
+
+  return {
+    Authorization: `${tokenSet.token_type ?? "DPoP"} ${tokenSet.access_token}`,
+    DPoP: dpop,
+  };
+}
+
 /** Upstream proofs for GET /v1/latr/saves (paginated listRecords only). */
 export async function createListSavesUpstreamDpopProofPool(
   oauthSession: OAuthSession,
@@ -85,11 +151,15 @@ export async function latrGatewayFetch(
 
   const upstream = pdsXrpcMethodForGatewayRequest(method, gatewayPath);
   const upstreamHeaders: Record<string, string> = {};
-  const sessionWithTokenSet = oauthSession as OAuthSession & {
-    getTokenSet(refresh: boolean | "auto"): Promise<{ access_token: string }>;
-  };
+  const sessionWithTokenSet = oauthSession as SessionWithTokenSet;
   const tokenSet = await sessionWithTokenSet.getTokenSet("auto");
   const proofOptions = { accessToken: tokenSet.access_token };
+  const userAuthHeaders = await buildGatewayUserAuthHeaders(
+    oauthSession,
+    method,
+    url,
+    tokenSet
+  );
 
   if (method === "POST" && gatewayPath === LATR_GATEWAY_SAVES_PATH) {
     upstreamHeaders[LATR_UPSTREAM_DPOP_HEADER] =
@@ -109,11 +179,12 @@ export async function latrGatewayFetch(
     );
   }
 
-  return oauthSession.fetchHandler(url, {
+  return fetch(url, {
     ...init,
     headers: {
       Accept: "application/json",
       ...clientHeaders,
+      ...userAuthHeaders,
       ...upstreamHeaders,
       ...(init?.headers ?? {}),
     },

--- a/packages/latr-web-client/src/latrRepo.test.ts
+++ b/packages/latr-web-client/src/latrRepo.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 
 import { configureLatrGateway } from "./latrGatewayConfig";
@@ -7,6 +7,8 @@ import {
   markLexiconMigrationComplete,
 } from "./lexiconMigrationCache";
 import { LatrRepo } from "./latrRepo";
+
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   configureLatrGateway({
@@ -18,6 +20,10 @@ beforeEach(() => {
     apiKey: "",
   });
   clearLexiconMigrationCacheForTests();
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
 });
 
 function mockOAuthSession(
@@ -55,9 +61,9 @@ function mockOAuthSession(
 describe("LatrRepo Gateway Facade", () => {
   test("listSavedItems migrates legacy lexicons then reads saved items", async () => {
     const calls: string[] = [];
-    const oauth = mockOAuthSession(async (url, init) => {
+    globalThis.fetch = (async (url, init) => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
-      if (url.includes("/v1/latr/migrate-lexicons")) {
+      if (String(url).includes("/v1/latr/migrate-lexicons")) {
         return new Response(
           JSON.stringify({
             ok: true,
@@ -86,6 +92,12 @@ describe("LatrRepo Gateway Facade", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -110,12 +122,18 @@ describe("LatrRepo Gateway Facade", () => {
   test("listSavedItems skips migrate when lexicon migration already completed", async () => {
     markLexiconMigrationComplete("did:plc:viewer");
     const calls: string[] = [];
-    const oauth = mockOAuthSession(async (url, init) => {
+    globalThis.fetch = (async (url, init) => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       return new Response(
         JSON.stringify({ records: [] }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -131,7 +149,7 @@ describe("LatrRepo Gateway Facade", () => {
 
   test("saveExternalUrl POSTs URL Body", async () => {
     let body = "";
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       body = String(init?.body ?? "");
       return new Response(
         JSON.stringify({
@@ -144,6 +162,12 @@ describe("LatrRepo Gateway Facade", () => {
         headers: { "Content-Type": "application/json" },
       }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
@@ -197,6 +197,7 @@ private func normalizeDPoPURL(_ raw: String) -> String? {
     }
     components.scheme = scheme
     components.host = host
+    components.query = nil
     components.fragment = nil
     if (scheme == "https" && components.port == 443) || (scheme == "http" && components.port == 80) {
         components.port = nil

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -98,6 +98,31 @@ final class AuthVerificationTests: XCTestCase {
         )
     }
 
+    func testDPoPAcceptsProofURLWithoutQueryString() throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let proof = try signedDPoP(
+            signingKey: key,
+            jwk: jwk,
+            htm: "GET",
+            htu: "https://api.testing.latr.link/v1/latr/og-preview",
+            accessToken: token
+        )
+
+        XCTAssertNoThrow(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(
+                    path: "/v1/latr/og-preview?url=https%3A%2F%2Fexample.com",
+                    scheme: nil,
+                    authority: "api.testing.latr.link"
+                )
+            )
+        )
+    }
+
     func testOAuthVerifierRejectsTamperedAccessTokenSignature() async throws {
         let key = P256.Signing.PrivateKey()
         let jwk = jwk(for: key.publicKey)


### PR DESCRIPTION
## Summary
- Normalize DPoP verification to accept the expected scheme consistently across gateway auth and route handling.
- Update JWT and OAuth verification plumbing to align upstream proof validation with the gateway’s auth context.
- Adjust web client tests and repo client coverage to match the revised DPoP behavior.

## Testing
- Added and updated gateway auth and upstream proof pool tests.
- Updated web client unit tests for DPoP-related request behavior.
- Not run (not requested).