### PR TITLE
Support ES256K ATProto OAuth access token verification

### DIFF
--- a/services/latr-gateway/Package.swift
+++ b/services/latr-gateway/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.12.0"),
+        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.23.2"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.21.0"),
     ],
     targets: [
@@ -24,6 +25,7 @@ let package = Package(
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "P256K", package: "swift-secp256k1"),
                 .product(name: "PostgresNIO", package: "postgres-nio"),
             ],
             path: "Sources/LatrGatewayLib"

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
@@ -1,6 +1,7 @@
 import AsyncHTTPClient
 import Crypto
 import Foundation
+import P256K
 
 private struct OAuthTokenHeader: Decodable {
     let alg: String
@@ -19,6 +20,7 @@ private struct JWKSet: Decodable {
 private struct OAuthJWK: Decodable {
     let kty: String
     let kid: String?
+    let alg: String?
     let crv: String?
     let x: String?
     let y: String?
@@ -67,6 +69,8 @@ public struct OAuthTokenVerifier: Sendable {
         }
         guard let key = jwks.keys.first(where: { jwk in
             guard jwk.kty == expectedKeyType else { return false }
+            guard jwk.alg == nil || jwk.alg == header.alg else { return false }
+            guard jwk.curveSupports(alg: header.alg) else { return false }
             guard let kid = header.kid else { return true }
             return jwk.kid == kid
         }) else {
@@ -135,8 +139,7 @@ public struct OAuthTokenVerifier: Sendable {
         let signature = try jwtSignature(jwt)
         switch header.alg {
         case "ES256":
-            guard key.crv == "P-256",
-                  let x = key.x.flatMap(base64URLDecode),
+            guard let x = key.x.flatMap(base64URLDecode),
                   let y = key.y.flatMap(base64URLDecode),
                   x.count == 32,
                   y.count == 32
@@ -146,6 +149,18 @@ public struct OAuthTokenVerifier: Sendable {
             let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
             let ecdsa = try P256.Signing.ECDSASignature(rawRepresentation: signature)
             return publicKey.isValidSignature(ecdsa, for: signingInput)
+        case "ES256K":
+            guard let x = key.x.flatMap(base64URLDecode),
+                  let y = key.y.flatMap(base64URLDecode),
+                  x.count == 32,
+                  y.count == 32,
+                  signature.count == 64
+            else {
+                return false
+            }
+            let publicKey = try P256K.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+            let ecdsa = try P256K.Signing.ECDSASignature(compactRepresentation: signature)
+            return publicKey.isValidSignature(ecdsa, for: signingInput)
         default:
             return false
         }
@@ -153,8 +168,21 @@ public struct OAuthTokenVerifier: Sendable {
 
     private func keyType(for alg: String) -> String? {
         switch alg {
-        case "ES256": "EC"
+        case "ES256", "ES256K": "EC"
         default: nil
+        }
+    }
+}
+
+private extension OAuthJWK {
+    func curveSupports(alg: String) -> Bool {
+        switch alg {
+        case "ES256":
+            crv == "P-256"
+        case "ES256K":
+            crv == "secp256k1"
+        default:
+            false
         }
     }
 }

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -5,6 +5,7 @@ import Hummingbird
 import HTTPTypes
 @testable import LatrGatewayLib
 import NIOCore
+import P256K
 import XCTest
 
 final class AuthVerificationTests: XCTestCase {
@@ -192,10 +193,14 @@ final class AuthVerificationTests: XCTestCase {
         try await httpClient.shutdown()
     }
 
-    func testOAuthVerifierReportsUnsupportedES256KTokens() async throws {
-        let key = P256.Signing.PrivateKey()
-        let jwk = jwk(for: key.publicKey)
-        let token = try unsupportedES256KAccessToken(dpopJWK: jwk)
+    func testOAuthVerifierAcceptsES256KAccessTokens() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessToken(signingKey: signingKey, dpopJWK: dpopJWK)
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         let verifier = OAuthTokenVerifier(
             httpClient: httpClient,
@@ -204,7 +209,39 @@ final class AuthVerificationTests: XCTestCase {
                     return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
                 }
                 if url.absoluteString == "https://auth.example/jwks.json" {
-                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","crv":"secp256k1","x":"test","y":"test"}]}"#
+                    let jwk = es256kJWK(for: signingKey.publicKey)
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","alg":"ES256K","crv":"secp256k1","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        let verified = try await verifier.verify(accessToken: token, dpopJWK: dpopJWK)
+
+        XCTAssertEqual(verified.payload.sub, "did:plc:test")
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierRejectsTamperedES256KAccessTokens() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessToken(signingKey: signingKey, dpopJWK: dpopJWK)
+        let tampered = "\(token)a"
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwk = es256kJWK(for: signingKey.publicKey)
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","alg":"ES256K","crv":"secp256k1","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
                     return Data(jwks.utf8)
                 }
                 throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
@@ -212,8 +249,68 @@ final class AuthVerificationTests: XCTestCase {
         )
 
         do {
+            _ = try await verifier.verify(accessToken: tampered, dpopJWK: dpopJWK)
+            XCTFail("tampered ES256K token should fail verification")
+        } catch let error as GatewayError {
+            XCTAssertEqual(error.code, "invalid_token")
+        }
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierRejectsES256KTokenWithoutDPoPConfirmation() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessTokenWithoutDPoPConfirmation(signingKey: signingKey)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwk = es256kJWK(for: signingKey.publicKey)
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","alg":"ES256K","crv":"secp256k1","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
+            _ = try await verifier.verify(accessToken: token, dpopJWK: dpopJWK)
+            XCTFail("ES256K token without cnf.jkt should fail verification")
+        } catch let error as GatewayError {
+            XCTAssertEqual(error.message, "Token missing DPoP confirmation")
+        }
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierReportsUnsupportedAccessTokenAlgorithms() async throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try unsupportedAccessToken(alg: "EdDSA", dpopJWK: jwk)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    return Data(#"{"keys":[]}"#.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
             _ = try await verifier.verify(accessToken: token, dpopJWK: jwk)
-            XCTFail("ES256K token verification should fail until secp256k1 support is added")
+            XCTFail("unsupported token algorithm should fail verification")
         } catch let error as GatewayError {
             XCTAssertEqual(error.code, "unsupported_token_alg")
         }
@@ -258,8 +355,21 @@ final class AuthVerificationTests: XCTestCase {
         return try signJWT(header: header, payload: payload, signingKey: signingKey)
     }
 
-    private func unsupportedES256KAccessToken(dpopJWK: DPoPJWK) throws -> String {
-        let header = #"{"typ":"at+jwt","alg":"ES256K"}"#
+    private func signedES256KAccessToken(signingKey: P256K.Signing.PrivateKey, dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"ES256K","kid":"test-key"}"#
+        let jkt = try jwkThumbprint(dpopJWK)
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func signedES256KAccessTokenWithoutDPoPConfirmation(signingKey: P256K.Signing.PrivateKey) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"ES256K","kid":"test-key"}"#
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func unsupportedAccessToken(alg: String, dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"\#(alg)","kid":"test-key"}"#
         let jkt = try jwkThumbprint(dpopJWK)
         let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
         return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
@@ -285,6 +395,12 @@ final class AuthVerificationTests: XCTestCase {
         return "\(signingInput).\(base64URLEncode(signature))"
     }
 
+    private func signJWT(header: String, payload: String, signingKey: P256K.Signing.PrivateKey) throws -> String {
+        let signingInput = "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8)))"
+        let signature = signingKey.signature(for: Data(signingInput.utf8)).compactRepresentation
+        return "\(signingInput).\(base64URLEncode(signature))"
+    }
+
     private func jwk(for publicKey: P256.Signing.PublicKey) -> DPoPJWK {
         let raw = publicKey.x963Representation
         return DPoPJWK(
@@ -293,5 +409,26 @@ final class AuthVerificationTests: XCTestCase {
             x: base64URLEncode(raw.dropFirst().prefix(32)),
             y: base64URLEncode(raw.dropFirst(33).prefix(32))
         )
+    }
+}
+
+private func es256kJWK(for publicKey: P256K.Signing.PublicKey) -> (x: String, y: String) {
+    let raw = publicKey.uncompressedRepresentation
+    return (
+        x: base64URLEncode(raw.dropFirst().prefix(32)),
+        y: base64URLEncode(raw.dropFirst(33).prefix(32))
+    )
+}
+
+private extension Data {
+    init(hex: String) {
+        var bytes: [UInt8] = []
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            bytes.append(UInt8(hex[index..<nextIndex], radix: 16)!)
+            index = nextIndex
+        }
+        self.init(bytes)
     }
 }


### PR DESCRIPTION
## Summary
- Add secp256k1 JWT verification support to the gateway OAuth verifier
- Enforce `alg` and curve matching when selecting JWKs
- Expand gateway tests to cover valid ES256K tokens, tampering, DPoP confirmation checks, and unsupported algorithms

## Testing
- Added unit tests for ES256K verification paths in `services/latr-gateway`
- Added regression coverage for unsupported token algorithms and missing `cnf.jkt` handling