### PR TITLE
Promote L@tr gateway OAuth and DPoP fixes to production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 - Public foundation packages use descriptive names (`ATProtoPrimitiveKit`, `ATProtoAuthKit`, …), not a `Stygian` prefix; app-specific packages (`latr-kit`, `latr-packages`, …) keep product names.
 - Shared package dependencies should resolve via git/npm/SwiftPM remotes — not sibling local paths — so CI and contributors run without monorepo-local checkouts.
 - Swift gateway CI should treat compiler warnings as errors.
-- Official gateway credentials should be server-side secrets (Next.js BFF routes) when possible; L@tr web uses **`LATR_GATEWAY_CLIENT_CREDENTIAL`** (not `NEXT_PUBLIC_*`; root layout reads server env per request and `next.config.ts` inlines at build — still in the bundle) and the extension uses **`VITE_*`** — interim for browser-direct gateway calls. Third-party clients use the registration API separately.
+- Official gateway credentials should be server-side secrets. L@tr web uses the same-origin Next.js **`/api/latr-gateway/*`** proxy, which forwards OAuth/DPoP headers and injects **`LATR_GATEWAY_CLIENT_CREDENTIAL`** or split **`LATR_GATEWAY_CLIENT_ID`** + **`LATR_GATEWAY_API_KEY`** server-side; do **not** expose these as `NEXT_PUBLIC_*` or serialize them into the client. The extension uses **`VITE_*`** — interim for browser-direct gateway calls. Third-party clients use the registration API separately.
 
 ## Learned Workspace Facts
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -61,9 +61,9 @@ NEXT_PUBLIC_APP_ENV=local
 #   prod  → https://latr-link-prod-gateway.fly.dev
 # NEXT_PUBLIC_LATR_GATEWAY_URL=https://api.testing.latr.link
 
-# Preferred: split API key from latrkit.dev (client id must match exactly, e.g. latr-link-web)
+# Preferred: split API key from latrkit.dev (client id must match exactly, e.g. latr-link-web).
 # Set on Vercel for Preview + Production (testing.latr.link uses Preview deployments).
-# Do not use NEXT_PUBLIC_* — these are server-injected into the client bundle.
+# Do not use NEXT_PUBLIC_* — the Next.js /api/latr-gateway proxy injects these server-side.
 # LATR_GATEWAY_CLIENT_ID=latr-link-web
 # LATR_GATEWAY_API_KEY=lk_...
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,11 +5,6 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_ENV:
       process.env.NEXT_PUBLIC_APP_ENV ?? process.env.APP_ENV ?? "",
-    /** Inlined at build from Vercel/local env (not NEXT_PUBLIC_*); still ships in the client bundle. */
-    LATR_GATEWAY_CLIENT_CREDENTIAL:
-      process.env.LATR_GATEWAY_CLIENT_CREDENTIAL ?? "",
-    LATR_GATEWAY_CLIENT_ID: process.env.LATR_GATEWAY_CLIENT_ID ?? "",
-    LATR_GATEWAY_API_KEY: process.env.LATR_GATEWAY_API_KEY ?? "",
   },
   allowedDevOrigins: ["127.0.0.1"],
   async rewrites() {

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { GET, POST } from "./route";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  APP_ENV: process.env.APP_ENV,
+  NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
+  NEXT_PUBLIC_LATR_GATEWAY_URL: process.env.NEXT_PUBLIC_LATR_GATEWAY_URL,
+  LATR_GATEWAY_CLIENT_ID: process.env.LATR_GATEWAY_CLIENT_ID,
+  LATR_GATEWAY_API_KEY: process.env.LATR_GATEWAY_API_KEY,
+  LATR_GATEWAY_CLIENT_CREDENTIAL: process.env.LATR_GATEWAY_CLIENT_CREDENTIAL,
+};
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  restoreEnv();
+});
+
+describe("/api/latr-gateway proxy", () => {
+  test("Injects Server Split Credentials And Preserves Browser DPoP Headers", async () => {
+    process.env.LATR_GATEWAY_CLIENT_ID = "latr-link-web";
+    process.env.LATR_GATEWAY_API_KEY = "lk_server";
+    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = "https://api.testing.latr.link";
+
+    let target = "";
+    let headers = new Headers();
+    globalThis.fetch = (async (url, init) => {
+      target = String(url);
+      headers = new Headers(init?.headers);
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const req = new Request(
+      "https://testing.latr.link/api/latr-gateway/v1/latr/saves?limit=10",
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: "DPoP access",
+          DPoP: "gateway-proof",
+          "X-ATProto-Upstream-DPoP": "upstream-proof",
+          "X-Latr-Client-Id": "browser-client",
+          "X-Latr-API-Key": "lk_browser",
+          "X-Forwarded-Host": "testing.latr.link",
+          "X-Forwarded-Proto": "https",
+        },
+      }
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(target).toBe("https://api.testing.latr.link/v1/latr/saves?limit=10");
+    expect(headers.get("Authorization")).toBe("DPoP access");
+    expect(headers.get("DPoP")).toBe("gateway-proof");
+    expect(headers.get("X-ATProto-Upstream-DPoP")).toBe("upstream-proof");
+    expect(headers.get("X-Latr-Client-Id")).toBe("latr-link-web");
+    expect(headers.get("X-Latr-API-Key")).toBe("lk_server");
+    expect(headers.get("X-Original-URI")).toBe(
+      "/api/latr-gateway/v1/latr/saves?limit=10"
+    );
+  });
+
+  test("Forwards Request Bodies", async () => {
+    process.env.LATR_GATEWAY_CLIENT_CREDENTIAL = "legacy-server-credential";
+    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = "https://api.testing.latr.link";
+
+    let body = "";
+    let headers = new Headers();
+    globalThis.fetch = (async (_url, init) => {
+      headers = new Headers(init?.headers);
+      body = await new Response(init?.body).text();
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const req = new Request(
+      "https://testing.latr.link/api/latr-gateway/v1/latr/saves",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Forwarded-Host": "testing.latr.link",
+          "X-Forwarded-Proto": "https",
+        },
+        body: JSON.stringify({ kind: "url", url: "https://example.com" }),
+      }
+    );
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(headers.get("X-Latr-Official-Client")).toBe("legacy-server-credential");
+    expect(body).toBe(JSON.stringify({ kind: "url", url: "https://example.com" }));
+  });
+});

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
@@ -108,4 +108,71 @@ describe("/api/latr-gateway proxy", () => {
     expect(headers.get("X-Latr-Official-Client")).toBe("legacy-server-credential");
     expect(body).toBe(JSON.stringify({ kind: "url", url: "https://example.com" }));
   });
+
+  test("Fails Fast for Hosted Gateway When Server Credentials Are Missing", async () => {
+    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = "https://api.testing.latr.link";
+    delete process.env.LATR_GATEWAY_CLIENT_ID;
+    delete process.env.LATR_GATEWAY_API_KEY;
+    delete process.env.LATR_GATEWAY_CLIENT_CREDENTIAL;
+
+    let didFetch = false;
+    globalThis.fetch = (async () => {
+      didFetch = true;
+      return new Response(null, { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const req = new Request(
+      "https://testing.latr.link/api/latr-gateway/v1/latr/saves",
+      {
+        headers: {
+          Authorization: "DPoP access",
+          DPoP: "gateway-proof",
+          "X-Forwarded-Host": "testing.latr.link",
+          "X-Forwarded-Proto": "https",
+        },
+      }
+    );
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("gateway_client_credentials_unconfigured");
+    expect(didFetch).toBe(false);
+  });
+
+  test("Allows Local Loopback Gateway Without Server Credentials", async () => {
+    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = "http://127.0.0.1:8080";
+    delete process.env.LATR_GATEWAY_CLIENT_ID;
+    delete process.env.LATR_GATEWAY_API_KEY;
+    delete process.env.LATR_GATEWAY_CLIENT_CREDENTIAL;
+
+    let headers = new Headers();
+    globalThis.fetch = (async (_url, init) => {
+      headers = new Headers(init?.headers);
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const req = new Request(
+      "http://127.0.0.1:3000/api/latr-gateway/v1/latr/saves",
+      {
+        headers: {
+          Authorization: "DPoP access",
+          DPoP: "gateway-proof",
+          "X-Forwarded-Host": "127.0.0.1:3000",
+          "X-Forwarded-Proto": "http",
+        },
+      }
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(headers.get("X-Latr-Client-Id")).toBeNull();
+    expect(headers.get("X-Latr-API-Key")).toBeNull();
+    expect(headers.get("X-Latr-Official-Client")).toBeNull();
+  });
 });

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
@@ -35,14 +35,17 @@ describe("/api/latr-gateway proxy", () => {
 
     let target = "";
     let headers = new Headers();
-    globalThis.fetch = (async (url, init) => {
+    globalThis.fetch = (async (
+      url: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1]
+    ) => {
       target = String(url);
       headers = new Headers(init?.headers);
       return new Response(JSON.stringify({ records: [] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const req = new Request(
       "https://testing.latr.link/api/latr-gateway/v1/latr/saves?limit=10",
@@ -82,14 +85,17 @@ describe("/api/latr-gateway proxy", () => {
 
     let body = "";
     let headers = new Headers();
-    globalThis.fetch = (async (_url, init) => {
+    globalThis.fetch = (async (
+      _url: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1]
+    ) => {
       headers = new Headers(init?.headers);
       body = await new Response(init?.body).text();
       return new Response(JSON.stringify({ ok: true }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const req = new Request(
       "https://testing.latr.link/api/latr-gateway/v1/latr/saves",
@@ -141,6 +147,45 @@ describe("/api/latr-gateway proxy", () => {
     expect(res.status).toBe(500);
     expect(body.error).toBe("gateway_client_credentials_unconfigured");
     expect(didFetch).toBe(false);
+  });
+
+  test("Adds Forwarding Diagnostics When Upstream Rejects Auth", async () => {
+    process.env.LATR_GATEWAY_CLIENT_ID = "latr-link-web";
+    process.env.LATR_GATEWAY_API_KEY = "lk_server";
+    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = "https://api.testing.latr.link";
+
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          error: "missing_auth",
+          message: "Missing Authorization header",
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as unknown as typeof fetch;
+
+    const req = new Request(
+      "https://testing.latr.link/api/latr-gateway/v1/latr/saves",
+      {
+        headers: {
+          "x-latr-user-authorization": "DPoP access",
+          "x-latr-user-dpop": "gateway-proof",
+          "X-Forwarded-Host": "testing.latr.link",
+          "X-Forwarded-Proto": "https",
+        },
+      }
+    );
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("X-Latr-Proxy-User-Authorization")).toBe("custom");
+    expect(res.headers.get("X-Latr-Proxy-User-DPoP")).toBe("custom");
+    expect(res.headers.get("X-Latr-Proxy-Upstream-Authorization")).toBe("present");
+    expect(res.headers.get("X-Latr-Proxy-Upstream-DPoP")).toBe("present");
   });
 
   test("Allows Local Loopback Gateway Without Server Credentials", async () => {

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
@@ -69,6 +69,8 @@ describe("/api/latr-gateway proxy", () => {
     expect(target).toBe("https://api.testing.latr.link/v1/latr/saves?limit=10");
     expect(headers.get("Authorization")).toBe("DPoP access");
     expect(headers.get("DPoP")).toBe("gateway-proof");
+    expect(headers.get("X-Latr-Forwarded-Authorization")).toBe("DPoP access");
+    expect(headers.get("X-Latr-Forwarded-DPoP")).toBe("gateway-proof");
     expect(headers.get("X-ATProto-Upstream-DPoP")).toBe("upstream-proof");
     expect(headers.get("X-Latr-Client-Id")).toBe("latr-link-web");
     expect(headers.get("X-Latr-API-Key")).toBe("lk_server");
@@ -186,6 +188,8 @@ describe("/api/latr-gateway proxy", () => {
     expect(res.headers.get("X-Latr-Proxy-User-DPoP")).toBe("custom");
     expect(res.headers.get("X-Latr-Proxy-Upstream-Authorization")).toBe("present");
     expect(res.headers.get("X-Latr-Proxy-Upstream-DPoP")).toBe("present");
+    expect(res.headers.get("X-Latr-Proxy-Forwarded-Authorization")).toBe("present");
+    expect(res.headers.get("X-Latr-Proxy-Forwarded-DPoP")).toBe("present");
   });
 
   test("Allows Local Loopback Gateway Without Server Credentials", async () => {

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.test.ts
@@ -49,8 +49,8 @@ describe("/api/latr-gateway proxy", () => {
       {
         headers: {
           Accept: "application/json",
-          Authorization: "DPoP access",
-          DPoP: "gateway-proof",
+          "X-Latr-User-Authorization": "DPoP access",
+          "X-Latr-User-DPoP": "gateway-proof",
           "X-ATProto-Upstream-DPoP": "upstream-proof",
           "X-Latr-Client-Id": "browser-client",
           "X-Latr-API-Key": "lk_browser",
@@ -69,6 +69,8 @@ describe("/api/latr-gateway proxy", () => {
     expect(headers.get("X-ATProto-Upstream-DPoP")).toBe("upstream-proof");
     expect(headers.get("X-Latr-Client-Id")).toBe("latr-link-web");
     expect(headers.get("X-Latr-API-Key")).toBe("lk_server");
+    expect(headers.get("X-Latr-User-Authorization")).toBeNull();
+    expect(headers.get("X-Latr-User-DPoP")).toBeNull();
     expect(headers.get("X-Original-URI")).toBe(
       "/api/latr-gateway/v1/latr/saves?limit=10"
     );

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from "next/server";
+import {
+  DEFAULT_DEV_LATR_GATEWAY_URL,
+  DEFAULT_PROD_LATR_GATEWAY_URL,
+  DEFAULT_TESTING_LATR_GATEWAY_URL,
+  LATR_GATEWAY_PROXY_BASE_PATH,
+  LOCAL_LATR_GATEWAY_URL,
+  readGatewayClientCredentialFromEnv,
+  readGatewayClientCredentialsFromEnv,
+} from "@/lib/latrGatewayUrl";
+import {
+  LATR_API_KEY_HEADER,
+  LATR_CLIENT_ID_HEADER,
+  LATR_OFFICIAL_CLIENT_HEADER,
+} from "latr-web-client/latrGatewayConfig";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const FORWARDED_REQUEST_HEADERS = new Set([
+  "accept",
+  "authorization",
+  "content-type",
+  "dpop",
+  "x-atproto-upstream-dpop",
+]);
+
+const RESPONSE_HEADERS_TO_DROP = new Set([
+  "connection",
+  "content-encoding",
+  "content-length",
+  "keep-alive",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+type RequestWithOptionalNextUrl = Request & { nextUrl?: URL };
+
+function firstForwardedHeader(req: Request, name: string): string | undefined {
+  return req.headers.get(name)?.split(",")[0]?.trim() || undefined;
+}
+
+function requestUrl(req: Request): URL {
+  return (req as RequestWithOptionalNextUrl).nextUrl ?? new URL(req.url);
+}
+
+function forwardedHost(req: Request): string {
+  return firstForwardedHeader(req, "x-forwarded-host") ?? requestUrl(req).host;
+}
+
+function forwardedProto(req: Request): string {
+  return (
+    firstForwardedHeader(req, "x-forwarded-proto") ??
+    requestUrl(req).protocol.replace(":", "")
+  );
+}
+
+function serverGatewayBaseUrl(req: Request): string {
+  const configured = process.env.NEXT_PUBLIC_LATR_GATEWAY_URL?.trim();
+  if (configured) return configured.replace(/\/$/, "");
+
+  switch (forwardedHost(req).toLowerCase()) {
+    case "testing.latr.link":
+      return DEFAULT_TESTING_LATR_GATEWAY_URL;
+    case "latr.link":
+    case "www.latr.link":
+      return DEFAULT_PROD_LATR_GATEWAY_URL;
+    default:
+      break;
+  }
+
+  switch ((process.env.NEXT_PUBLIC_APP_ENV ?? process.env.APP_ENV)?.trim()) {
+    case "prod":
+      return DEFAULT_PROD_LATR_GATEWAY_URL;
+    case "dev":
+      return DEFAULT_DEV_LATR_GATEWAY_URL;
+    case "test":
+      return DEFAULT_TESTING_LATR_GATEWAY_URL;
+    default:
+      return LOCAL_LATR_GATEWAY_URL;
+  }
+}
+
+function gatewayCredentialHeaders(): Headers {
+  const headers = new Headers();
+  const { clientId, apiKey } = readGatewayClientCredentialsFromEnv();
+  if (clientId && apiKey) {
+    headers.set(LATR_CLIENT_ID_HEADER, clientId);
+    headers.set(LATR_API_KEY_HEADER, apiKey);
+    return headers;
+  }
+
+  const credential = readGatewayClientCredentialFromEnv();
+  if (credential) {
+    headers.set(LATR_OFFICIAL_CLIENT_HEADER, credential);
+  }
+  return headers;
+}
+
+function forwardedRequestHeaders(req: Request): Headers {
+  const headers = new Headers();
+  const url = requestUrl(req);
+  for (const [name, value] of req.headers) {
+    if (FORWARDED_REQUEST_HEADERS.has(name.toLowerCase())) {
+      headers.set(name, value);
+    }
+  }
+
+  headers.set("X-Forwarded-Host", forwardedHost(req));
+  headers.set("X-Forwarded-Proto", forwardedProto(req));
+  headers.set(
+    "X-Original-URI",
+    `${LATR_GATEWAY_PROXY_BASE_PATH}${url.pathname.slice(LATR_GATEWAY_PROXY_BASE_PATH.length)}${url.search}`
+  );
+
+  for (const [name, value] of gatewayCredentialHeaders()) {
+    headers.set(name, value);
+  }
+  return headers;
+}
+
+async function proxyLatrGateway(req: Request): Promise<Response> {
+  const url = requestUrl(req);
+  const path = url.pathname.slice(LATR_GATEWAY_PROXY_BASE_PATH.length);
+  const target = `${serverGatewayBaseUrl(req)}${path}${url.search}`;
+  const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body;
+  const upstream = await fetch(target, {
+    method: req.method,
+    headers: forwardedRequestHeaders(req),
+    body,
+    redirect: "manual",
+    cache: "no-store",
+    // Required by fetch when forwarding a streaming Request body.
+    duplex: body ? "half" : undefined,
+  } as RequestInit & { duplex?: "half" });
+
+  const headers = new Headers();
+  for (const [name, value] of upstream.headers) {
+    if (!RESPONSE_HEADERS_TO_DROP.has(name.toLowerCase())) {
+      headers.set(name, value);
+    }
+  }
+  headers.set("Cache-Control", "no-store");
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}
+
+export const GET = proxyLatrGateway;
+export const POST = proxyLatrGateway;
+export const PATCH = proxyLatrGateway;
+export const DELETE = proxyLatrGateway;
+export const OPTIONS = proxyLatrGateway;

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.ts
@@ -13,6 +13,10 @@ import {
   LATR_CLIENT_ID_HEADER,
   LATR_OFFICIAL_CLIENT_HEADER,
 } from "latr-web-client/latrGatewayConfig";
+import {
+  LATR_PROXY_USER_AUTHORIZATION_HEADER,
+  LATR_PROXY_USER_DPOP_HEADER,
+} from "latr-web-client/latrGatewayClient";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -23,6 +27,8 @@ const FORWARDED_REQUEST_HEADERS = new Set([
   "content-type",
   "dpop",
   "x-atproto-upstream-dpop",
+  "x-latr-user-authorization",
+  "x-latr-user-dpop",
 ]);
 
 const RESPONSE_HEADERS_TO_DROP = new Set([
@@ -121,6 +127,18 @@ function forwardedRequestHeaders(req: Request): Headers {
     if (FORWARDED_REQUEST_HEADERS.has(name.toLowerCase())) {
       headers.set(name, value);
     }
+  }
+
+  const proxiedAuthorization = headers.get(LATR_PROXY_USER_AUTHORIZATION_HEADER);
+  if (proxiedAuthorization) {
+    headers.set("Authorization", proxiedAuthorization);
+    headers.delete(LATR_PROXY_USER_AUTHORIZATION_HEADER);
+  }
+
+  const proxiedDpop = headers.get(LATR_PROXY_USER_DPOP_HEADER);
+  if (proxiedDpop) {
+    headers.set("DPoP", proxiedDpop);
+    headers.delete(LATR_PROXY_USER_DPOP_HEADER);
   }
 
   headers.set("X-Forwarded-Host", forwardedHost(req));

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.ts
@@ -31,6 +31,9 @@ const FORWARDED_REQUEST_HEADERS = new Set([
   "x-latr-user-dpop",
 ]);
 
+const LATR_FORWARDED_AUTHORIZATION_HEADER = "X-Latr-Forwarded-Authorization";
+const LATR_FORWARDED_DPOP_HEADER = "X-Latr-Forwarded-DPoP";
+
 const RESPONSE_HEADERS_TO_DROP = new Set([
   "connection",
   "content-encoding",
@@ -151,6 +154,7 @@ function forwardedRequestHeaders(req: Request): {
   ]);
   if (proxiedAuthorization) {
     headers.set("authorization", proxiedAuthorization);
+    headers.set(LATR_FORWARDED_AUTHORIZATION_HEADER, proxiedAuthorization);
     headers.delete(LATR_PROXY_USER_AUTHORIZATION_HEADER);
     headers.delete(LATR_PROXY_USER_AUTHORIZATION_HEADER.toLowerCase());
   }
@@ -161,6 +165,7 @@ function forwardedRequestHeaders(req: Request): {
   ]);
   if (proxiedDpop) {
     headers.set("dpop", proxiedDpop);
+    headers.set(LATR_FORWARDED_DPOP_HEADER, proxiedDpop);
     headers.delete(LATR_PROXY_USER_DPOP_HEADER);
     headers.delete(LATR_PROXY_USER_DPOP_HEADER.toLowerCase());
   }
@@ -242,6 +247,14 @@ async function proxyLatrGateway(req: Request): Promise<Response> {
     responseHeaders.set(
       "X-Latr-Proxy-Upstream-DPoP",
       requestHeaders.get("dpop") ? "present" : "missing"
+    );
+    responseHeaders.set(
+      "X-Latr-Proxy-Forwarded-Authorization",
+      requestHeaders.get(LATR_FORWARDED_AUTHORIZATION_HEADER) ? "present" : "missing"
+    );
+    responseHeaders.set(
+      "X-Latr-Proxy-Forwarded-DPoP",
+      requestHeaders.get(LATR_FORWARDED_DPOP_HEADER) ? "present" : "missing"
     );
   }
 

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.ts
@@ -97,6 +97,23 @@ function gatewayCredentialHeaders(): Headers {
   return headers;
 }
 
+function isLoopbackGatewayUrl(raw: string): boolean {
+  try {
+    const { hostname } = new URL(raw);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function hasGatewayCredentialHeaders(headers: Headers): boolean {
+  return (
+    Boolean(headers.get(LATR_OFFICIAL_CLIENT_HEADER)) ||
+    (Boolean(headers.get(LATR_CLIENT_ID_HEADER)) &&
+      Boolean(headers.get(LATR_API_KEY_HEADER)))
+  );
+}
+
 function forwardedRequestHeaders(req: Request): Headers {
   const headers = new Headers();
   const url = requestUrl(req);
@@ -122,11 +139,26 @@ function forwardedRequestHeaders(req: Request): Headers {
 async function proxyLatrGateway(req: Request): Promise<Response> {
   const url = requestUrl(req);
   const path = url.pathname.slice(LATR_GATEWAY_PROXY_BASE_PATH.length);
-  const target = `${serverGatewayBaseUrl(req)}${path}${url.search}`;
+  const gatewayBase = serverGatewayBaseUrl(req);
+  const target = `${gatewayBase}${path}${url.search}`;
+  const requestHeaders = forwardedRequestHeaders(req);
+  if (
+    !isLoopbackGatewayUrl(gatewayBase) &&
+    !hasGatewayCredentialHeaders(requestHeaders)
+  ) {
+    return NextResponse.json(
+      {
+        error: "gateway_client_credentials_unconfigured",
+        message:
+          "L@tr gateway client credentials are not configured on the web server.",
+      },
+      { status: 500 }
+    );
+  }
   const body = req.method === "GET" || req.method === "HEAD" ? undefined : req.body;
   const upstream = await fetch(target, {
     method: req.method,
-    headers: forwardedRequestHeaders(req),
+    headers: requestHeaders,
     body,
     redirect: "manual",
     cache: "no-store",
@@ -134,18 +166,18 @@ async function proxyLatrGateway(req: Request): Promise<Response> {
     duplex: body ? "half" : undefined,
   } as RequestInit & { duplex?: "half" });
 
-  const headers = new Headers();
+  const responseHeaders = new Headers();
   for (const [name, value] of upstream.headers) {
     if (!RESPONSE_HEADERS_TO_DROP.has(name.toLowerCase())) {
-      headers.set(name, value);
+      responseHeaders.set(name, value);
     }
   }
-  headers.set("Cache-Control", "no-store");
+  responseHeaders.set("Cache-Control", "no-store");
 
   return new NextResponse(upstream.body, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers,
+    headers: responseHeaders,
   });
 }
 

--- a/apps/web/src/app/api/latr-gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/latr-gateway/[...path]/route.ts
@@ -42,6 +42,11 @@ const RESPONSE_HEADERS_TO_DROP = new Set([
 
 type RequestWithOptionalNextUrl = Request & { nextUrl?: URL };
 
+type ProxyForwardingDiagnostics = {
+  userAuthorizationSource: "custom" | "direct" | "missing";
+  userDpopSource: "custom" | "direct" | "missing";
+};
+
 function firstForwardedHeader(req: Request, name: string): string | undefined {
   return req.headers.get(name)?.split(",")[0]?.trim() || undefined;
 }
@@ -120,7 +125,18 @@ function hasGatewayCredentialHeaders(headers: Headers): boolean {
   );
 }
 
-function forwardedRequestHeaders(req: Request): Headers {
+function firstHeaderValue(req: Request, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = req.headers.get(name)?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function forwardedRequestHeaders(req: Request): {
+  headers: Headers;
+  diagnostics: ProxyForwardingDiagnostics;
+} {
   const headers = new Headers();
   const url = requestUrl(req);
   for (const [name, value] of req.headers) {
@@ -129,16 +145,24 @@ function forwardedRequestHeaders(req: Request): Headers {
     }
   }
 
-  const proxiedAuthorization = headers.get(LATR_PROXY_USER_AUTHORIZATION_HEADER);
+  const proxiedAuthorization = firstHeaderValue(req, [
+    LATR_PROXY_USER_AUTHORIZATION_HEADER,
+    LATR_PROXY_USER_AUTHORIZATION_HEADER.toLowerCase(),
+  ]);
   if (proxiedAuthorization) {
-    headers.set("Authorization", proxiedAuthorization);
+    headers.set("authorization", proxiedAuthorization);
     headers.delete(LATR_PROXY_USER_AUTHORIZATION_HEADER);
+    headers.delete(LATR_PROXY_USER_AUTHORIZATION_HEADER.toLowerCase());
   }
 
-  const proxiedDpop = headers.get(LATR_PROXY_USER_DPOP_HEADER);
+  const proxiedDpop = firstHeaderValue(req, [
+    LATR_PROXY_USER_DPOP_HEADER,
+    LATR_PROXY_USER_DPOP_HEADER.toLowerCase(),
+  ]);
   if (proxiedDpop) {
-    headers.set("DPoP", proxiedDpop);
+    headers.set("dpop", proxiedDpop);
     headers.delete(LATR_PROXY_USER_DPOP_HEADER);
+    headers.delete(LATR_PROXY_USER_DPOP_HEADER.toLowerCase());
   }
 
   headers.set("X-Forwarded-Host", forwardedHost(req));
@@ -151,7 +175,21 @@ function forwardedRequestHeaders(req: Request): Headers {
   for (const [name, value] of gatewayCredentialHeaders()) {
     headers.set(name, value);
   }
-  return headers;
+  return {
+    headers,
+    diagnostics: {
+      userAuthorizationSource: proxiedAuthorization
+        ? "custom"
+        : headers.get("authorization")
+          ? "direct"
+          : "missing",
+      userDpopSource: proxiedDpop
+        ? "custom"
+        : headers.get("dpop")
+          ? "direct"
+          : "missing",
+    },
+  };
 }
 
 async function proxyLatrGateway(req: Request): Promise<Response> {
@@ -159,7 +197,7 @@ async function proxyLatrGateway(req: Request): Promise<Response> {
   const path = url.pathname.slice(LATR_GATEWAY_PROXY_BASE_PATH.length);
   const gatewayBase = serverGatewayBaseUrl(req);
   const target = `${gatewayBase}${path}${url.search}`;
-  const requestHeaders = forwardedRequestHeaders(req);
+  const { headers: requestHeaders, diagnostics } = forwardedRequestHeaders(req);
   if (
     !isLoopbackGatewayUrl(gatewayBase) &&
     !hasGatewayCredentialHeaders(requestHeaders)
@@ -191,6 +229,21 @@ async function proxyLatrGateway(req: Request): Promise<Response> {
     }
   }
   responseHeaders.set("Cache-Control", "no-store");
+  if (!upstream.ok) {
+    responseHeaders.set(
+      "X-Latr-Proxy-User-Authorization",
+      diagnostics.userAuthorizationSource
+    );
+    responseHeaders.set("X-Latr-Proxy-User-DPoP", diagnostics.userDpopSource);
+    responseHeaders.set(
+      "X-Latr-Proxy-Upstream-Authorization",
+      requestHeaders.get("authorization") ? "present" : "missing"
+    );
+    responseHeaders.set(
+      "X-Latr-Proxy-Upstream-DPoP",
+      requestHeaders.get("dpop") ? "present" : "missing"
+    );
+  }
 
   return new NextResponse(upstream.body, {
     status: upstream.status,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -13,8 +13,6 @@ import {
 import "./globals.css";
 import {
   buildGatewayWindowBootstrap,
-  readGatewayClientCredentialFromEnv,
-  readGatewayClientCredentialsFromEnv,
 } from "@/lib/latrGatewayUrl";
 import { Providers } from "./providers";
 
@@ -65,8 +63,6 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const appEnv = getAppEnv();
-  const gatewayClientCredential = readGatewayClientCredentialFromEnv();
-  const gatewayClientCredentials = readGatewayClientCredentialsFromEnv();
   const gatewayBootstrap = buildGatewayWindowBootstrap(toLatrGatewayAppEnv(appEnv));
   const bodyStyle = {
     "--env-banner-offset": environmentBannerOffset(appEnv),
@@ -85,11 +81,7 @@ export default function RootLayout({
         <Script id="latr-gateway-bootstrap" strategy="beforeInteractive">
           {`window.__LATR_GATEWAY_BOOTSTRAP__=${JSON.stringify(gatewayBootstrap)};`}
         </Script>
-        <Providers
-          gatewayClientCredential={gatewayClientCredential}
-          gatewayClientId={gatewayClientCredentials.clientId}
-          gatewayApiKey={gatewayClientCredentials.apiKey}
-        >
+        <Providers>
           <EnvironmentBanner appEnv={appEnv} />
           {children}
         </Providers>

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -8,11 +8,7 @@ import {
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { AuthProvider } from "@/hooks/useAuth";
-import {
-  setInjectedGatewayClientCredential,
-  setInjectedGatewayClientCredentials,
-  syncLatrGatewayFromBrowser,
-} from "@/lib/latrGatewayUrl";
+import { syncLatrGatewayFromBrowser } from "@/lib/latrGatewayUrl";
 
 const QUERY_PERSIST_KEY = "latr.link.react-query.v1";
 const QUERY_PERSIST_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 7;
@@ -24,33 +20,14 @@ function shouldDehydrateQuery(query: Query): boolean {
 
 export function Providers({
   children,
-  gatewayClientCredential,
-  gatewayClientId,
-  gatewayApiKey,
 }: {
   children: React.ReactNode;
-  /** From server layout (`LATR_GATEWAY_CLIENT_CREDENTIAL` at request time). */
-  gatewayClientCredential?: string;
-  /** From server layout (`LATR_GATEWAY_CLIENT_ID` at request time). */
-  gatewayClientId?: string;
-  /** From server layout (`LATR_GATEWAY_API_KEY` at request time). */
-  gatewayApiKey?: string;
 }) {
-  setInjectedGatewayClientCredential(gatewayClientCredential);
-  setInjectedGatewayClientCredentials({
-    clientId: gatewayClientId,
-    apiKey: gatewayApiKey,
-  });
   syncLatrGatewayFromBrowser();
 
   useLayoutEffect(() => {
-    setInjectedGatewayClientCredential(gatewayClientCredential);
-    setInjectedGatewayClientCredentials({
-      clientId: gatewayClientId,
-      apiKey: gatewayApiKey,
-    });
     syncLatrGatewayFromBrowser();
-  }, [gatewayClientCredential, gatewayClientId, gatewayApiKey]);
+  }, []);
 
   const [queryClient] = useState(
     () =>

--- a/apps/web/src/lib/latrGatewayClient.ts
+++ b/apps/web/src/lib/latrGatewayClient.ts
@@ -19,6 +19,7 @@ export async function latrGatewayFetch(
   ...args: Parameters<typeof sharedLatrGatewayFetch>
 ): Promise<Response> {
   syncLatrGatewayFromBrowser();
+  args[3] = { ...args[3], skipClientCredential: true };
   return sharedLatrGatewayFetch(...args);
 }
 
@@ -26,5 +27,6 @@ export async function latrGatewayJson<T>(
   ...args: Parameters<typeof sharedLatrGatewayJson>
 ): Promise<T> {
   syncLatrGatewayFromBrowser();
+  args[3] = { ...args[3], skipClientCredential: true };
   return sharedLatrGatewayJson<T>(...args);
 }

--- a/apps/web/src/lib/latrGatewayUrl.test.ts
+++ b/apps/web/src/lib/latrGatewayUrl.test.ts
@@ -7,12 +7,8 @@ import {
   DEFAULT_PROD_LATR_GATEWAY_URL,
   LOCAL_LATR_GATEWAY_URL,
   latrGatewayBaseUrl,
-  syncLatrGatewayFromBrowser,
+  latrGatewayProxyBaseUrlForOrigin,
 } from "@/lib/latrGatewayUrl";
-import {
-  assertLatrGatewayClientCredential,
-  latrGatewayClientHeaders,
-} from "latr-web-client/latrGatewayConfig";
 
 const originalEnv = {
   NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
@@ -71,27 +67,9 @@ describe("Latr Gateway Base URL", () => {
     expect(latrGatewayBaseUrl()).toBe("https://custom.gateway.example");
   });
 
-  test("Browser Runtime Uses Same-origin Proxy Without Client Credential Headers", () => {
-    const previousWindow = globalThis.window;
-    globalThis.window = {
-      location: {
-        href: "https://testing.latr.link/library",
-        origin: "https://testing.latr.link",
-      },
-      __LATR_GATEWAY_BOOTSTRAP__: {
-        appEnv: "dev",
-      },
-    } as Window & typeof globalThis;
-
-    try {
-      syncLatrGatewayFromBrowser();
-      expect(latrGatewayBaseUrl()).toBe(
-        `https://testing.latr.link${LATR_GATEWAY_PROXY_BASE_PATH}`
-      );
-      expect(latrGatewayClientHeaders()).toEqual({});
-      expect(() => assertLatrGatewayClientCredential()).not.toThrow();
-    } finally {
-      globalThis.window = previousWindow;
-    }
+  test("Builds Same-origin Browser Proxy URL", () => {
+    expect(latrGatewayProxyBaseUrlForOrigin("https://testing.latr.link")).toBe(
+      `https://testing.latr.link${LATR_GATEWAY_PROXY_BASE_PATH}`
+    );
   });
 });

--- a/apps/web/src/lib/latrGatewayUrl.test.ts
+++ b/apps/web/src/lib/latrGatewayUrl.test.ts
@@ -2,11 +2,17 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { configureLatrGateway } from "latr-web-client/latrGatewayConfig";
 
 import {
+  LATR_GATEWAY_PROXY_BASE_PATH,
   DEFAULT_DEV_LATR_GATEWAY_URL,
   DEFAULT_PROD_LATR_GATEWAY_URL,
   LOCAL_LATR_GATEWAY_URL,
   latrGatewayBaseUrl,
+  syncLatrGatewayFromBrowser,
 } from "@/lib/latrGatewayUrl";
+import {
+  assertLatrGatewayClientCredential,
+  latrGatewayClientHeaders,
+} from "latr-web-client/latrGatewayConfig";
 
 const originalEnv = {
   NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
@@ -63,5 +69,29 @@ describe("Latr Gateway Base URL", () => {
   test("Honors Explicit NEXT_PUBLIC_LATR_GATEWAY_URL", () => {
     process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = "https://custom.gateway.example/";
     expect(latrGatewayBaseUrl()).toBe("https://custom.gateway.example");
+  });
+
+  test("Browser Runtime Uses Same-origin Proxy Without Client Credential Headers", () => {
+    const previousWindow = globalThis.window;
+    globalThis.window = {
+      location: {
+        href: "https://testing.latr.link/library",
+        origin: "https://testing.latr.link",
+      },
+      __LATR_GATEWAY_BOOTSTRAP__: {
+        appEnv: "dev",
+      },
+    } as Window & typeof globalThis;
+
+    try {
+      syncLatrGatewayFromBrowser();
+      expect(latrGatewayBaseUrl()).toBe(
+        `https://testing.latr.link${LATR_GATEWAY_PROXY_BASE_PATH}`
+      );
+      expect(latrGatewayClientHeaders()).toEqual({});
+      expect(() => assertLatrGatewayClientCredential()).not.toThrow();
+    } finally {
+      globalThis.window = previousWindow;
+    }
   });
 });

--- a/apps/web/src/lib/latrGatewayUrl.ts
+++ b/apps/web/src/lib/latrGatewayUrl.ts
@@ -51,8 +51,12 @@ function readWindowGatewayBootstrap(): LatrGatewayWindowBootstrap | undefined {
   return window.__LATR_GATEWAY_BOOTSTRAP__;
 }
 
+function isBrowserRuntime(): boolean {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
 export function browserLatrGatewayProxyBaseUrl(): string | undefined {
-  if (typeof window === "undefined") return undefined;
+  if (!isBrowserRuntime()) return undefined;
   return latrGatewayProxyBaseUrlForOrigin(window.location.origin);
 }
 
@@ -62,13 +66,13 @@ export function latrGatewayProxyBaseUrlForOrigin(origin: string): string {
 
 /** Push web env + current browser hostname into shared `latr-web-client` config. */
 export function syncLatrGatewayFromBrowser(): void {
+  if (!isBrowserRuntime()) return;
+
   let testingHostname: string | undefined;
-  if (typeof window !== "undefined") {
-    try {
-      testingHostname = new URL(window.location.href).hostname;
-    } catch {
-      //
-    }
+  try {
+    testingHostname = new URL(window.location.href).hostname;
+  } catch {
+    //
   }
 
   const bootstrap = readWindowGatewayBootstrap();
@@ -95,12 +99,27 @@ export function syncLatrGatewayFromBrowser(): void {
 
 registerLatrGatewayConfigSync(syncLatrGatewayFromBrowser);
 
+function syncLatrGatewayFromProcessEnv(): void {
+  configureLatrGateway({
+    gatewayUrl: process.env.NEXT_PUBLIC_LATR_GATEWAY_URL?.trim() ?? "",
+    appEnv: toLatrGatewayAppEnv(),
+    testingHostname: "",
+    clientCredential: "",
+    clientId: "",
+    apiKey: "",
+  });
+}
+
 /**
  * Base URL for `services/latr-gateway` API calls.
  * Hostname mapping wins over loopback overrides; non-loopback explicit URL wins otherwise.
  */
 export function latrGatewayBaseUrl(): string {
-  syncLatrGatewayFromBrowser();
+  if (isBrowserRuntime()) {
+    syncLatrGatewayFromBrowser();
+  } else {
+    syncLatrGatewayFromProcessEnv();
+  }
   return sharedLatrGatewayBaseUrl();
 }
 

--- a/apps/web/src/lib/latrGatewayUrl.ts
+++ b/apps/web/src/lib/latrGatewayUrl.ts
@@ -6,6 +6,7 @@ import {
   LOCAL_LATR_GATEWAY_URL,
   latrGatewayBaseUrl as sharedLatrGatewayBaseUrl,
   publishLatrGatewayWindowBootstrap,
+  registerLatrGatewayConfigSync,
   type LatrGatewayWindowBootstrap,
 } from "latr-web-client/latrGatewayConfig";
 
@@ -119,6 +120,8 @@ export function latrGatewayBaseUrl(): string {
   }
   return sharedLatrGatewayBaseUrl();
 }
+
+registerLatrGatewayConfigSync(syncLatrGatewayFromBrowser);
 
 function testingGatewayUrl(): string {
   const configured = process.env.NEXT_PUBLIC_LATR_GATEWAY_URL?.trim();

--- a/apps/web/src/lib/latrGatewayUrl.ts
+++ b/apps/web/src/lib/latrGatewayUrl.ts
@@ -53,7 +53,11 @@ function readWindowGatewayBootstrap(): LatrGatewayWindowBootstrap | undefined {
 
 export function browserLatrGatewayProxyBaseUrl(): string | undefined {
   if (typeof window === "undefined") return undefined;
-  return `${window.location.origin}${LATR_GATEWAY_PROXY_BASE_PATH}`;
+  return latrGatewayProxyBaseUrlForOrigin(window.location.origin);
+}
+
+export function latrGatewayProxyBaseUrlForOrigin(origin: string): string {
+  return `${origin}${LATR_GATEWAY_PROXY_BASE_PATH}`;
 }
 
 /** Push web env + current browser hostname into shared `latr-web-client` config. */

--- a/apps/web/src/lib/latrGatewayUrl.ts
+++ b/apps/web/src/lib/latrGatewayUrl.ts
@@ -6,7 +6,6 @@ import {
   LOCAL_LATR_GATEWAY_URL,
   latrGatewayBaseUrl as sharedLatrGatewayBaseUrl,
   publishLatrGatewayWindowBootstrap,
-  registerLatrGatewayConfigSync,
   type LatrGatewayWindowBootstrap,
 } from "latr-web-client/latrGatewayConfig";
 
@@ -96,8 +95,6 @@ export function syncLatrGatewayFromBrowser(): void {
     appEnv,
   });
 }
-
-registerLatrGatewayConfigSync(syncLatrGatewayFromBrowser);
 
 function syncLatrGatewayFromProcessEnv(): void {
   configureLatrGateway({

--- a/apps/web/src/lib/latrGatewayUrl.ts
+++ b/apps/web/src/lib/latrGatewayUrl.ts
@@ -21,51 +21,25 @@ export {
 
 export type { LatrGatewayWindowBootstrap };
 
-/** Credential from the server layout (runtime env); wins over client `process.env`. */
-let injectedGatewayClientCredential: string | undefined;
-let injectedGatewayClientId: string | undefined;
-let injectedGatewayApiKey: string | undefined;
-
-export function setInjectedGatewayClientCredential(
-  credential: string | undefined
-): void {
-  const trimmed = credential?.trim();
-  injectedGatewayClientCredential = trimmed || undefined;
-}
-
-export function setInjectedGatewayClientCredentials(credentials: {
-  clientId?: string;
-  apiKey?: string;
-}): void {
-  const clientId = credentials.clientId?.trim();
-  const apiKey = credentials.apiKey?.trim();
-  injectedGatewayClientId = clientId || undefined;
-  injectedGatewayApiKey = apiKey || undefined;
-}
+export const LATR_GATEWAY_PROXY_BASE_PATH = "/api/latr-gateway";
 
 function readEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
   return value || undefined;
 }
 
-/** Read gateway client credential on the server (layout) or from build-time env. */
+/** Read gateway client credential on the server only. */
 export function readGatewayClientCredentialFromEnv(): string | undefined {
-  return (
-    readEnv("LATR_GATEWAY_CLIENT_CREDENTIAL") ??
-    readEnv("NEXT_PUBLIC_LATR_GATEWAY_CLIENT_CREDENTIAL")
-  );
+  return readEnv("LATR_GATEWAY_CLIENT_CREDENTIAL");
 }
 
-/** Read split gateway credentials on the server (layout) or from build-time env. */
+/** Read split gateway credentials on the server only. */
 export function readGatewayClientCredentialsFromEnv(): {
   clientId?: string;
   apiKey?: string;
 } {
-  const clientId =
-    readEnv("LATR_GATEWAY_CLIENT_ID") ??
-    readEnv("NEXT_PUBLIC_LATR_GATEWAY_CLIENT_ID");
-  const apiKey =
-    readEnv("LATR_GATEWAY_API_KEY") ?? readEnv("NEXT_PUBLIC_LATR_GATEWAY_API_KEY");
+  const clientId = readEnv("LATR_GATEWAY_CLIENT_ID");
+  const apiKey = readEnv("LATR_GATEWAY_API_KEY");
   return {
     ...(clientId ? { clientId } : {}),
     ...(apiKey ? { apiKey } : {}),
@@ -75,6 +49,11 @@ export function readGatewayClientCredentialsFromEnv(): {
 function readWindowGatewayBootstrap(): LatrGatewayWindowBootstrap | undefined {
   if (typeof window === "undefined") return undefined;
   return window.__LATR_GATEWAY_BOOTSTRAP__;
+}
+
+export function browserLatrGatewayProxyBaseUrl(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return `${window.location.origin}${LATR_GATEWAY_PROXY_BASE_PATH}`;
 }
 
 /** Push web env + current browser hostname into shared `latr-web-client` config. */
@@ -89,49 +68,24 @@ export function syncLatrGatewayFromBrowser(): void {
   }
 
   const bootstrap = readWindowGatewayBootstrap();
-  const credential =
-    injectedGatewayClientCredential ??
-    bootstrap?.clientCredential?.trim() ??
-    readGatewayClientCredentialFromEnv();
-  const splitFromInjection =
-    injectedGatewayClientId && injectedGatewayApiKey
-      ? { clientId: injectedGatewayClientId, apiKey: injectedGatewayApiKey }
-      : undefined;
-  const splitFromBootstrap =
-    bootstrap?.clientId?.trim() && bootstrap?.apiKey?.trim()
-      ? {
-          clientId: bootstrap.clientId.trim(),
-          apiKey: bootstrap.apiKey.trim(),
-        }
-      : undefined;
-  const splitFromEnv = readGatewayClientCredentialsFromEnv();
-  const clientId =
-    splitFromInjection?.clientId ??
-    splitFromBootstrap?.clientId ??
-    splitFromEnv.clientId;
-  const apiKey =
-    splitFromInjection?.apiKey ??
-    splitFromBootstrap?.apiKey ??
-    splitFromEnv.apiKey;
   const gatewayUrl =
-    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL?.trim() ??
-    bootstrap?.gatewayUrl?.trim();
+    browserLatrGatewayProxyBaseUrl() ??
+    bootstrap?.gatewayUrl?.trim() ??
+    process.env.NEXT_PUBLIC_LATR_GATEWAY_URL?.trim();
   const appEnv = bootstrap?.appEnv ?? toLatrGatewayAppEnv();
 
   configureLatrGateway({
     gatewayUrl,
     appEnv,
     testingHostname: testingHostname ?? "",
-    clientCredential: credential ?? "",
-    clientId: clientId ?? "",
-    apiKey: apiKey ?? "",
+    clientCredential: "",
+    clientId: "",
+    apiKey: "",
   });
 
   publishLatrGatewayWindowBootstrap({
     ...(gatewayUrl ? { gatewayUrl } : {}),
     appEnv,
-    ...(credential ? { clientCredential: credential } : {}),
-    ...(clientId && apiKey ? { clientId, apiKey } : {}),
   });
 }
 
@@ -169,13 +123,8 @@ export function inferGatewayApiBase(origin?: string): string | null {
 export function buildGatewayWindowBootstrap(
   appEnv: ReturnType<typeof toLatrGatewayAppEnv>
 ): LatrGatewayWindowBootstrap {
-  const credentials = readGatewayClientCredentialsFromEnv();
-  const clientCredential = readGatewayClientCredentialFromEnv();
   const gatewayUrl = process.env.NEXT_PUBLIC_LATR_GATEWAY_URL?.trim();
   return {
-    ...(credentials.clientId ? { clientId: credentials.clientId } : {}),
-    ...(credentials.apiKey ? { apiKey: credentials.apiKey } : {}),
-    ...(clientCredential ? { clientCredential } : {}),
     ...(gatewayUrl ? { gatewayUrl } : {}),
     appEnv,
   };

--- a/apps/web/src/lib/latrRepo.test.ts
+++ b/apps/web/src/lib/latrRepo.test.ts
@@ -4,8 +4,28 @@ import { configureLatrGateway } from "latr-web-client/latrGatewayConfig";
 import { LatrRepo } from "latr-web-client/latrRepo";
 
 const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_WINDOW = globalThis.window;
+const ORIGINAL_ENV = {
+  NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
+  APP_ENV: process.env.APP_ENV,
+  NEXT_PUBLIC_LATR_GATEWAY_URL: process.env.NEXT_PUBLIC_LATR_GATEWAY_URL,
+};
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
 
 beforeEach(() => {
+  globalThis.window = ORIGINAL_WINDOW;
+  process.env.NEXT_PUBLIC_APP_ENV = "local";
+  delete process.env.APP_ENV;
+  delete process.env.NEXT_PUBLIC_LATR_GATEWAY_URL;
   configureLatrGateway({
     appEnv: "local",
     gatewayUrl: "http://127.0.0.1:8080",
@@ -18,6 +38,8 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
+  globalThis.window = ORIGINAL_WINDOW;
+  restoreEnv();
 });
 
 function mockOAuthSession(

--- a/apps/web/src/lib/latrRepo.test.ts
+++ b/apps/web/src/lib/latrRepo.test.ts
@@ -4,28 +4,8 @@ import { configureLatrGateway } from "latr-web-client/latrGatewayConfig";
 import { LatrRepo } from "latr-web-client/latrRepo";
 
 const ORIGINAL_FETCH = globalThis.fetch;
-const ORIGINAL_WINDOW = globalThis.window;
-const ORIGINAL_ENV = {
-  NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
-  APP_ENV: process.env.APP_ENV,
-  NEXT_PUBLIC_LATR_GATEWAY_URL: process.env.NEXT_PUBLIC_LATR_GATEWAY_URL,
-};
-
-function restoreEnv(): void {
-  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-}
 
 beforeEach(() => {
-  globalThis.window = ORIGINAL_WINDOW;
-  process.env.NEXT_PUBLIC_APP_ENV = "local";
-  delete process.env.APP_ENV;
-  delete process.env.NEXT_PUBLIC_LATR_GATEWAY_URL;
   configureLatrGateway({
     appEnv: "local",
     gatewayUrl: "http://127.0.0.1:8080",
@@ -38,8 +18,6 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
-  globalThis.window = ORIGINAL_WINDOW;
-  restoreEnv();
 });
 
 function mockOAuthSession(
@@ -142,9 +120,9 @@ describe("Latrrepo Gateway Facade", () => {
       return new Response(
         JSON.stringify({ ok: true, kind: "url", storage: "external" }),
         {
-        status: 201,
-        headers: { "Content-Type": "application/json" },
-      }
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }
       );
     }) as typeof fetch;
     const oauth = mockOAuthSession(async () => {
@@ -202,16 +180,5 @@ describe("Latrrepo Gateway Facade", () => {
     const repo = new LatrRepo(oauth, "did:plc:viewer");
     await repo.unsave("item-rkey");
     expect(method).toBe("DELETE");
-  });
-});
-
-describe("Latr Gateway Base URL", () => {
-  test("Re-exports Env-aware Gateway URL Resolution", async () => {
-    const prev = process.env.NEXT_PUBLIC_LATR_GATEWAY_URL;
-    process.env.NEXT_PUBLIC_APP_ENV = "local";
-    delete process.env.NEXT_PUBLIC_LATR_GATEWAY_URL;
-    const { latrGatewayBaseUrl } = await import("./latrGatewayClient");
-    expect(latrGatewayBaseUrl()).toBe("http://127.0.0.1:8080");
-    if (prev) process.env.NEXT_PUBLIC_LATR_GATEWAY_URL = prev;
   });
 });

--- a/apps/web/src/lib/latrRepo.test.ts
+++ b/apps/web/src/lib/latrRepo.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 import { configureLatrGateway } from "latr-web-client/latrGatewayConfig";
 import { LatrRepo } from "latr-web-client/latrRepo";
+
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   configureLatrGateway({
@@ -12,6 +14,10 @@ beforeEach(() => {
     clientId: "",
     apiKey: "",
   });
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
 });
 
 function mockOAuthSession(
@@ -49,9 +55,9 @@ function mockOAuthSession(
 describe("Latrrepo Gateway Facade", () => {
   test("listSavedItems migrates legacy lexicons then reads saved items", async () => {
     const calls: string[] = [];
-    const oauth = mockOAuthSession(async (url, init) => {
+    globalThis.fetch = (async (url, init) => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
-      if (url.includes("/v1/latr/migrate-lexicons")) {
+      if (String(url).includes("/v1/latr/migrate-lexicons")) {
         return new Response(
           JSON.stringify({
             ok: true,
@@ -80,6 +86,12 @@ describe("Latrrepo Gateway Facade", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -103,7 +115,7 @@ describe("Latrrepo Gateway Facade", () => {
 
   test("saveExternalUrl POSTs URL Body", async () => {
     let body = "";
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       body = String(init?.body ?? "");
       return new Response(
         JSON.stringify({ ok: true, kind: "url", storage: "external" }),
@@ -112,6 +124,12 @@ describe("Latrrepo Gateway Facade", () => {
         headers: { "Content-Type": "application/json" },
       }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -124,11 +142,17 @@ describe("Latrrepo Gateway Facade", () => {
 
   test("setItemState PATCHes State Route", async () => {
     let path = "";
-    const oauth = mockOAuthSession(async (url) => {
-      path = url;
+    globalThis.fetch = (async (url) => {
+      path = String(url);
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 
@@ -139,11 +163,17 @@ describe("Latrrepo Gateway Facade", () => {
 
   test("Unsave Deletes Item Route", async () => {
     let method = "";
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       method = init?.method ?? "";
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 

--- a/docs/architecture/latr-gateway.md
+++ b/docs/architecture/latr-gateway.md
@@ -128,7 +128,7 @@ Full template: [`services/latr-gateway/.env.example`](../../services/latr-gatewa
 | `LATR_GATEWAY_DEVELOPER_STORE_PATH` | No | `./data/developer-store.json` | JSON fallback when `DATABASE_URL` is unset (local dev) |
 | `LATR_GATEWAY_CLIENT_REGISTRY_PATH` | No | `./data/client-registry.json` | Legacy JSON registry (deprecated) |
 
-**L@tr web** — `LATR_GATEWAY_CLIENT_CREDENTIAL` or split `LATR_GATEWAY_CLIENT_ID` + `LATR_GATEWAY_API_KEY` via `next.config.ts`.
+**L@tr web** — `LATR_GATEWAY_CLIENT_CREDENTIAL` or split `LATR_GATEWAY_CLIENT_ID` + `LATR_GATEWAY_API_KEY` are server-only secrets. Browser calls go to the same-origin Next.js proxy at `/api/latr-gateway/*`; the proxy forwards OAuth/DPoP headers and injects gateway client credentials server-side.
 
 **The Social Wire** — `NEXT_PUBLIC_LATR_GATEWAY_CLIENT_ID` + `NEXT_PUBLIC_LATR_GATEWAY_API_KEY` (preferred) or legacy `NEXT_PUBLIC_LATR_GATEWAY_CLIENT_CREDENTIAL`.
 

--- a/packages/latr-web-client/package.json
+++ b/packages/latr-web-client/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@atproto/api": "^0.19.17",
     "@atproto/oauth-client-browser": "^0.3.42",
-    "@atproto/syntax": "^0.5.0",
-    "latr-packages": "github:Stygian-Tech/latr-packages#072eddc"
+    "@atproto/syntax": "^0.5.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.4",

--- a/packages/latr-web-client/src/latrGatewayClient.test.ts
+++ b/packages/latr-web-client/src/latrGatewayClient.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 import {
   LATR_GATEWAY_MIGRATE_LEXICONS_PATH,
@@ -7,6 +7,8 @@ import {
 
 import { configureLatrGateway } from "./latrGatewayConfig";
 import { latrGatewayFetch } from "./latrGatewayClient";
+
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   configureLatrGateway({
@@ -19,8 +21,13 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
 function mockOAuthSession(
-  handler: (url: string, init?: RequestInit) => Promise<Response>
+  handler: (url: string, init?: RequestInit) => Promise<Response>,
+  onJwtClaims?: (claims: Record<string, string | number>) => void
 ): OAuthSession {
   let proofCount = 0;
 
@@ -44,8 +51,9 @@ function mockOAuthSession(
       dpopKey: {
         bareJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
         algorithms: ["ES256"],
-        createJwt: async () => {
+        createJwt: async (_header: unknown, claims: Record<string, string | number>) => {
           proofCount += 1;
+          onJwtClaims?.(claims);
           return `proof-${proofCount}`;
         },
       },
@@ -60,13 +68,20 @@ describe("latrGatewayFetch upstream proofs", () => {
   test("GET /v1/latr/saves sends list-only upstream proofs", async () => {
     let upstreamHeader = "";
 
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       upstreamHeader = String(
         new Headers(init?.headers).get(LATR_UPSTREAM_DPOP_HEADER) ?? ""
       );
       return new Response(JSON.stringify({ records: [] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 
@@ -78,7 +93,7 @@ describe("latrGatewayFetch upstream proofs", () => {
   test("POST /v1/latr/migrate-lexicons sends migration upstream proofs", async () => {
     let upstreamHeader = "";
 
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       upstreamHeader = String(
         new Headers(init?.headers).get(LATR_UPSTREAM_DPOP_HEADER) ?? ""
       );
@@ -95,6 +110,13 @@ describe("latrGatewayFetch upstream proofs", () => {
           headers: { "Content-Type": "application/json" },
         }
       );
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     await latrGatewayFetch(oauth, LATR_GATEWAY_MIGRATE_LEXICONS_PATH, {
@@ -107,13 +129,20 @@ describe("latrGatewayFetch upstream proofs", () => {
   test("POST /v1/latr/saves sends save upstream proofs", async () => {
     let upstreamHeader = "";
 
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       upstreamHeader = String(
         new Headers(init?.headers).get(LATR_UPSTREAM_DPOP_HEADER) ?? ""
       );
       return new Response(JSON.stringify({ ok: true, kind: "url" }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
       });
     });
 
@@ -124,5 +153,41 @@ describe("latrGatewayFetch upstream proofs", () => {
     });
 
     expect(upstreamHeader.split(",")).toHaveLength(8);
+  });
+
+  test("sends explicit gateway Authorization and DPoP headers", async () => {
+    let authorization = "";
+    let dpop = "";
+    const claimsSeen: Record<string, string | number>[] = [];
+
+    globalThis.fetch = (async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      authorization = headers.get("Authorization") ?? "";
+      dpop = headers.get("DPoP") ?? "";
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(
+      async () =>
+        new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+          status: 400,
+          headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+        }),
+      (claims) => claimsSeen.push(claims)
+    );
+
+    await latrGatewayFetch(oauth, "/v1/latr/og-preview?url=https://example.com", {
+      method: "GET",
+    });
+
+    expect(authorization).toBe("DPoP test-access-token");
+    expect(dpop).toBe("proof-1");
+    expect(claimsSeen[0]).toMatchObject({
+      htm: "GET",
+      htu: "http://127.0.0.1:8080/v1/latr/og-preview",
+    });
   });
 });

--- a/packages/latr-web-client/src/latrGatewayClient.test.ts
+++ b/packages/latr-web-client/src/latrGatewayClient.test.ts
@@ -6,7 +6,11 @@ import {
 } from "latr-packages/gateway-client";
 
 import { configureLatrGateway } from "./latrGatewayConfig";
-import { latrGatewayFetch } from "./latrGatewayClient";
+import {
+  LATR_PROXY_USER_AUTHORIZATION_HEADER,
+  LATR_PROXY_USER_DPOP_HEADER,
+  latrGatewayFetch,
+} from "./latrGatewayClient";
 
 const ORIGINAL_FETCH = globalThis.fetch;
 
@@ -23,6 +27,9 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
+  if (typeof window !== "undefined") {
+    delete window.__LATR_GATEWAY_BOOTSTRAP__;
+  }
 });
 
 function mockOAuthSession(
@@ -189,5 +196,58 @@ describe("latrGatewayFetch upstream proofs", () => {
       htm: "GET",
       htu: "http://127.0.0.1:8080/v1/latr/og-preview",
     });
+  });
+
+  test("uses proxy user auth headers for same-origin web gateway proxy", async () => {
+    const previousWindow = globalThis.window;
+    globalThis.window = {
+      location: {
+        origin: "https://testing.latr.link",
+      },
+    } as Window & typeof globalThis;
+    configureLatrGateway({
+      appEnv: "dev",
+      gatewayUrl: "https://testing.latr.link/api/latr-gateway",
+      testingHostname: "testing.latr.link",
+      clientCredential: "",
+      clientId: "",
+      apiKey: "",
+    });
+
+    let authorization = "";
+    let dpop = "";
+    let proxyAuthorization = "";
+    let proxyDpop = "";
+
+    globalThis.fetch = (async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      authorization = headers.get("Authorization") ?? "";
+      dpop = headers.get("DPoP") ?? "";
+      proxyAuthorization =
+        headers.get(LATR_PROXY_USER_AUTHORIZATION_HEADER) ?? "";
+      proxyDpop = headers.get(LATR_PROXY_USER_DPOP_HEADER) ?? "";
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
+    });
+
+    try {
+      await latrGatewayFetch(oauth, "/v1/latr/saves", { method: "GET" });
+    } finally {
+      globalThis.window = previousWindow;
+    }
+
+    expect(authorization).toBe("");
+    expect(dpop).toBe("");
+    expect(proxyAuthorization).toBe("DPoP test-access-token");
+    expect(proxyDpop).toBe("proof-1");
   });
 });

--- a/packages/latr-web-client/src/latrGatewayClient.ts
+++ b/packages/latr-web-client/src/latrGatewayClient.ts
@@ -20,6 +20,9 @@ import {
 
 export { LATR_OFFICIAL_CLIENT_HEADER, LATR_UPSTREAM_DPOP_HEADER };
 
+export const LATR_PROXY_USER_AUTHORIZATION_HEADER = "X-Latr-User-Authorization";
+export const LATR_PROXY_USER_DPOP_HEADER = "X-Latr-User-DPoP";
+
 export type LatrGatewayFetchOptions = {
   /** Developer console management routes use OAuth only (no app API key). */
   skipClientCredential?: boolean;
@@ -88,6 +91,31 @@ async function buildGatewayUserAuthHeaders(
   return {
     Authorization: `${tokenSet.token_type ?? "DPoP"} ${tokenSet.access_token}`,
     DPoP: dpop,
+  };
+}
+
+function isSameOriginGatewayProxyUrl(url: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.origin === window.location.origin &&
+      parsed.pathname.startsWith("/api/latr-gateway/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function headersForGatewayHop(
+  url: string,
+  userAuthHeaders: Record<string, string>
+): Record<string, string> {
+  if (!isSameOriginGatewayProxyUrl(url)) return userAuthHeaders;
+
+  return {
+    [LATR_PROXY_USER_AUTHORIZATION_HEADER]: userAuthHeaders.Authorization,
+    [LATR_PROXY_USER_DPOP_HEADER]: userAuthHeaders.DPoP,
   };
 }
 
@@ -160,6 +188,7 @@ export async function latrGatewayFetch(
     url,
     tokenSet
   );
+  const hopUserAuthHeaders = headersForGatewayHop(url, userAuthHeaders);
 
   if (method === "POST" && gatewayPath === LATR_GATEWAY_SAVES_PATH) {
     upstreamHeaders[LATR_UPSTREAM_DPOP_HEADER] =
@@ -184,7 +213,7 @@ export async function latrGatewayFetch(
     headers: {
       Accept: "application/json",
       ...clientHeaders,
-      ...userAuthHeaders,
+      ...hopUserAuthHeaders,
       ...upstreamHeaders,
       ...(init?.headers ?? {}),
     },

--- a/packages/latr-web-client/src/latrGatewayClient.ts
+++ b/packages/latr-web-client/src/latrGatewayClient.ts
@@ -25,6 +25,72 @@ export type LatrGatewayFetchOptions = {
   skipClientCredential?: boolean;
 };
 
+type TokenSet = {
+  access_token: string;
+  token_type?: string;
+};
+
+type SessionWithTokenSet = OAuthSession & {
+  getTokenSet(refresh: boolean | "auto"): Promise<TokenSet>;
+};
+
+function stripQueryAndFragment(url: string): string {
+  const fragmentIndex = url.indexOf("#");
+  const queryIndex = url.indexOf("?");
+  if (fragmentIndex === -1 && queryIndex === -1) return url;
+  if (fragmentIndex === -1) return url.slice(0, queryIndex);
+  if (queryIndex === -1) return url.slice(0, fragmentIndex);
+  return url.slice(0, Math.min(fragmentIndex, queryIndex));
+}
+
+async function sha256Base64Url(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(digest);
+  let binary = "";
+  for (const byte of view) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function buildGatewayUserAuthHeaders(
+  oauthSession: OAuthSession,
+  method: string,
+  gatewayUrl: string,
+  tokenSet: TokenSet
+): Promise<Record<string, string>> {
+  const key = oauthSession.server.dpopKey;
+  const jwk = key.bareJwk;
+  if (!jwk) {
+    throw new Error("OAuth session DPoP key is unavailable");
+  }
+
+  const supported =
+    oauthSession.server.serverMetadata.dpop_signing_alg_values_supported;
+  const alg =
+    supported?.find((candidate) => key.algorithms.includes(candidate)) ??
+    key.algorithms[0];
+  if (!alg) {
+    throw new Error("OAuth session DPoP key has no supported algorithm");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const claims: Record<string, string | number> = {
+    iat: now,
+    jti: Math.random().toString(36).slice(2),
+    htm: method.toUpperCase(),
+    htu: stripQueryAndFragment(gatewayUrl),
+    ath: await sha256Base64Url(tokenSet.access_token),
+  };
+  const dpop = await key.createJwt({ alg, typ: "dpop+jwt", jwk }, claims);
+
+  return {
+    Authorization: `${tokenSet.token_type ?? "DPoP"} ${tokenSet.access_token}`,
+    DPoP: dpop,
+  };
+}
+
 /** Upstream proofs for GET /v1/latr/saves (paginated listRecords only). */
 export async function createListSavesUpstreamDpopProofPool(
   oauthSession: OAuthSession,
@@ -85,11 +151,15 @@ export async function latrGatewayFetch(
 
   const upstream = pdsXrpcMethodForGatewayRequest(method, gatewayPath);
   const upstreamHeaders: Record<string, string> = {};
-  const sessionWithTokenSet = oauthSession as OAuthSession & {
-    getTokenSet(refresh: boolean | "auto"): Promise<{ access_token: string }>;
-  };
+  const sessionWithTokenSet = oauthSession as SessionWithTokenSet;
   const tokenSet = await sessionWithTokenSet.getTokenSet("auto");
   const proofOptions = { accessToken: tokenSet.access_token };
+  const userAuthHeaders = await buildGatewayUserAuthHeaders(
+    oauthSession,
+    method,
+    url,
+    tokenSet
+  );
 
   if (method === "POST" && gatewayPath === LATR_GATEWAY_SAVES_PATH) {
     upstreamHeaders[LATR_UPSTREAM_DPOP_HEADER] =
@@ -109,11 +179,12 @@ export async function latrGatewayFetch(
     );
   }
 
-  return oauthSession.fetchHandler(url, {
+  return fetch(url, {
     ...init,
     headers: {
       Accept: "application/json",
       ...clientHeaders,
+      ...userAuthHeaders,
       ...upstreamHeaders,
       ...(init?.headers ?? {}),
     },

--- a/packages/latr-web-client/src/latrGatewayConfig.test.ts
+++ b/packages/latr-web-client/src/latrGatewayConfig.test.ts
@@ -131,4 +131,31 @@ describe("Latr Gateway Base URL", () => {
       globalThis.window = previousWindow;
     }
   });
+
+  test("resolveLatrGatewayConfig Keeps Same-origin Proxy Over Bootstrap Gateway URL", () => {
+    configureLatrGateway({
+      appEnv: "dev",
+      gatewayUrl: "https://testing.latr.link/api/latr-gateway",
+      testingHostname: "testing.latr.link",
+      clientId: "",
+      apiKey: "",
+    });
+    const previousWindow = globalThis.window;
+    globalThis.window = {
+      location: {
+        origin: "https://testing.latr.link",
+      },
+      __LATR_GATEWAY_BOOTSTRAP__: {
+        gatewayUrl: DEFAULT_TESTING_LATR_GATEWAY_URL,
+        appEnv: "dev",
+      },
+    } as Window & typeof globalThis;
+    try {
+      expect(latrGatewayBaseUrl(resolveLatrGatewayConfig())).toBe(
+        "https://testing.latr.link/api/latr-gateway"
+      );
+    } finally {
+      globalThis.window = previousWindow;
+    }
+  });
 });

--- a/packages/latr-web-client/src/latrGatewayConfig.ts
+++ b/packages/latr-web-client/src/latrGatewayConfig.ts
@@ -144,6 +144,19 @@ function isLoopbackGatewayUrl(url: string): boolean {
   }
 }
 
+function isSameOriginGatewayProxyUrl(url: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.origin === window.location.origin &&
+      parsed.pathname.replace(/\/$/, "") === "/api/latr-gateway"
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Known hosted web origins → gateway API base when env vars are misconfigured. */
 function gatewayForKnownHostname(hostname: string | undefined): string | undefined {
   switch (hostname?.toLowerCase()) {
@@ -216,6 +229,7 @@ export function assertLatrGatewayClientCredential(
   if (headers[LATR_OFFICIAL_CLIENT_HEADER]) return;
   const base = latrGatewayBaseUrl(resolved);
   if (isLoopbackGatewayUrl(base)) return;
+  if (isSameOriginGatewayProxyUrl(base)) return;
 
   const bootstrap = readWindowGatewayBootstrap();
   const bootstrapClientId = Boolean(bootstrap?.clientId?.trim());

--- a/packages/latr-web-client/src/latrGatewayConfig.ts
+++ b/packages/latr-web-client/src/latrGatewayConfig.ts
@@ -68,11 +68,13 @@ function mergeGatewayConfigWithWindowBootstrap(
   const apiKey = bootstrap.apiKey?.trim();
   const clientCredential = bootstrap.clientCredential?.trim();
   const gatewayUrl = bootstrap.gatewayUrl?.trim();
+  const keepConfiguredProxy =
+    config.gatewayUrl?.trim() && isSameOriginGatewayProxyUrl(config.gatewayUrl.trim());
 
   return {
     ...config,
     ...(bootstrap.appEnv ? { appEnv: bootstrap.appEnv } : {}),
-    ...(gatewayUrl ? { gatewayUrl } : {}),
+    ...(gatewayUrl && !keepConfiguredProxy ? { gatewayUrl } : {}),
     ...(clientCredential ? { clientCredential } : {}),
     ...(clientId && apiKey ? { clientId, apiKey } : {}),
   };

--- a/packages/latr-web-client/src/latrRepo.test.ts
+++ b/packages/latr-web-client/src/latrRepo.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 
 import { configureLatrGateway } from "./latrGatewayConfig";
@@ -7,6 +7,8 @@ import {
   markLexiconMigrationComplete,
 } from "./lexiconMigrationCache";
 import { LatrRepo } from "./latrRepo";
+
+const ORIGINAL_FETCH = globalThis.fetch;
 
 beforeEach(() => {
   configureLatrGateway({
@@ -18,6 +20,10 @@ beforeEach(() => {
     apiKey: "",
   });
   clearLexiconMigrationCacheForTests();
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
 });
 
 function mockOAuthSession(
@@ -55,9 +61,9 @@ function mockOAuthSession(
 describe("LatrRepo Gateway Facade", () => {
   test("listSavedItems migrates legacy lexicons then reads saved items", async () => {
     const calls: string[] = [];
-    const oauth = mockOAuthSession(async (url, init) => {
+    globalThis.fetch = (async (url, init) => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
-      if (url.includes("/v1/latr/migrate-lexicons")) {
+      if (String(url).includes("/v1/latr/migrate-lexicons")) {
         return new Response(
           JSON.stringify({
             ok: true,
@@ -86,6 +92,12 @@ describe("LatrRepo Gateway Facade", () => {
         }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -110,12 +122,18 @@ describe("LatrRepo Gateway Facade", () => {
   test("listSavedItems skips migrate when lexicon migration already completed", async () => {
     markLexiconMigrationComplete("did:plc:viewer");
     const calls: string[] = [];
-    const oauth = mockOAuthSession(async (url, init) => {
+    globalThis.fetch = (async (url, init) => {
       calls.push(`${init?.method ?? "GET"} ${url}`);
       return new Response(
         JSON.stringify({ records: [] }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");
@@ -131,7 +149,7 @@ describe("LatrRepo Gateway Facade", () => {
 
   test("saveExternalUrl POSTs URL Body", async () => {
     let body = "";
-    const oauth = mockOAuthSession(async (_url, init) => {
+    globalThis.fetch = (async (_url, init) => {
       body = String(init?.body ?? "");
       return new Response(
         JSON.stringify({
@@ -144,6 +162,12 @@ describe("LatrRepo Gateway Facade", () => {
         headers: { "Content-Type": "application/json" },
       }
       );
+    }) as typeof fetch;
+    const oauth = mockOAuthSession(async () => {
+      return new Response(JSON.stringify({ error: "Use DPoP nonce" }), {
+        status: 400,
+        headers: { "DPoP-Nonce": "fresh-pds-nonce" },
+      });
     });
 
     const repo = new LatrRepo(oauth, "did:plc:viewer");

--- a/services/latr-gateway/.env.example
+++ b/services/latr-gateway/.env.example
@@ -22,6 +22,11 @@ PLC_URL=https://plc.directory
 # via X-Latr-Official-Client remain supported during migration.
 # OAUTH_GATEWAY_ALLOWED_CLIENT_IDS is deprecated and ignored.
 # (latrkit.dev app: https://github.com/Stygian-Tech/latrkit-dev)
+#
+# Full OAuth access-token signature verification is enabled by default only in prod.
+# Dev/test/local still validate DPoP binding, token expiry, and DID subject while ES256K
+# verification support is added to the Swift gateway.
+# OAUTH_TOKEN_VERIFY_SIGNATURE=false
 
 # SPA origin for redirect_uris when serving /oauth/client-metadata.json from the gateway.
 # OAUTH_PUBLIC_ORIGIN=https://testing.latr.link

--- a/services/latr-gateway/.env.example
+++ b/services/latr-gateway/.env.example
@@ -22,11 +22,6 @@ PLC_URL=https://plc.directory
 # via X-Latr-Official-Client remain supported during migration.
 # OAUTH_GATEWAY_ALLOWED_CLIENT_IDS is deprecated and ignored.
 # (latrkit.dev app: https://github.com/Stygian-Tech/latrkit-dev)
-#
-# Full OAuth access-token signature verification is enabled by default only in prod.
-# Dev/test/local still validate DPoP binding, token expiry, and DID subject while ES256K
-# verification support is added to the Swift gateway.
-# OAUTH_TOKEN_VERIFY_SIGNATURE=false
 
 # SPA origin for redirect_uris when serving /oauth/client-metadata.json from the gateway.
 # OAUTH_PUBLIC_ORIGIN=https://testing.latr.link

--- a/services/latr-gateway/Package.swift
+++ b/services/latr-gateway/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.12.0"),
+        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.23.2"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.21.0"),
     ],
     targets: [
@@ -24,6 +25,7 @@ let package = Package(
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "P256K", package: "swift-secp256k1"),
                 .product(name: "PostgresNIO", package: "postgres-nio"),
             ],
             path: "Sources/LatrGatewayLib"

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -30,6 +30,18 @@ public let upstreamDPOPHeader = "X-ATProto-Upstream-DPoP"
 public let forwardedAuthorizationHeader = "X-Latr-Forwarded-Authorization"
 public let forwardedDPOPHeader = "X-Latr-Forwarded-DPoP"
 
+private func headerValue(from headers: HTTPFields, names: [String]) -> String? {
+    for name in names {
+        guard let fieldName = HTTPField.Name(name) else { continue }
+        if let value = headers[fieldName]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !value.isEmpty
+        {
+            return value
+        }
+    }
+    return nil
+}
+
 public func extractAccessTokenJWT(from authorization: String) -> String? {
     let trimmed = authorization.trimmingCharacters(in: .whitespacesAndNewlines)
     let lower = trimmed.lowercased()
@@ -45,37 +57,21 @@ public func extractAccessTokenJWT(from authorization: String) -> String? {
 }
 
 public func extractDPOPHeader(from headers: HTTPFields) -> String? {
-    for name in ["DPoP", "Dpop", "dpop", forwardedDPOPHeader] {
-        guard let fieldName = HTTPField.Name(name) else { continue }
-        if let value = headers[fieldName]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !value.isEmpty
-        {
-            return value
-        }
-    }
-    return nil
+    headerValue(
+        from: headers,
+        names: ["DPoP", "Dpop", "dpop", forwardedDPOPHeader, forwardedDPOPHeader.lowercased()]
+    )
 }
 
 public func extractAuthorizationHeader(from headers: HTTPFields) -> String? {
-    for name in ["Authorization", forwardedAuthorizationHeader] {
-        guard let fieldName = HTTPField.Name(name) else { continue }
-        if let value = headers[fieldName]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !value.isEmpty
-        {
-            return value
-        }
-    }
-    return nil
+    headerValue(
+        from: headers,
+        names: ["Authorization", "authorization", forwardedAuthorizationHeader, forwardedAuthorizationHeader.lowercased()]
+    )
 }
 
 public func extractUpstreamDPOPHeader(from headers: HTTPFields) -> String? {
-    guard let fieldName = HTTPField.Name(upstreamDPOPHeader) else { return nil }
-    guard let value = headers[fieldName]?.trimmingCharacters(in: .whitespacesAndNewlines),
-          !value.isEmpty
-    else {
-        return nil
-    }
-    return value
+    headerValue(from: headers, names: [upstreamDPOPHeader, upstreamDPOPHeader.lowercased()])
 }
 
 private func assertDPOPStructure(_ proof: String) throws {

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -128,7 +128,7 @@ public func authenticateRequest(
     let dpopJWK = try verifyGatewayDPoP(proof: dpop, accessToken: accessToken, request: request)
 
     let payload: JWTPayload
-    if config.oauthVerifyTokenSignature, let httpClient {
+    if let httpClient {
         payload = try await OAuthTokenVerifier(httpClient: httpClient)
             .verify(accessToken: accessToken, dpopJWK: dpopJWK)
             .payload

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -27,6 +27,8 @@ public struct AuthContext: Sendable {
 }
 
 public let upstreamDPOPHeader = "X-ATProto-Upstream-DPoP"
+public let forwardedAuthorizationHeader = "X-Latr-Forwarded-Authorization"
+public let forwardedDPOPHeader = "X-Latr-Forwarded-DPoP"
 
 public func extractAccessTokenJWT(from authorization: String) -> String? {
     let trimmed = authorization.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -43,7 +45,19 @@ public func extractAccessTokenJWT(from authorization: String) -> String? {
 }
 
 public func extractDPOPHeader(from headers: HTTPFields) -> String? {
-    for name in ["DPoP", "Dpop", "dpop"] {
+    for name in ["DPoP", "Dpop", "dpop", forwardedDPOPHeader] {
+        guard let fieldName = HTTPField.Name(name) else { continue }
+        if let value = headers[fieldName]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !value.isEmpty
+        {
+            return value
+        }
+    }
+    return nil
+}
+
+public func extractAuthorizationHeader(from headers: HTTPFields) -> String? {
+    for name in ["Authorization", forwardedAuthorizationHeader] {
         guard let fieldName = HTTPField.Name(name) else { continue }
         if let value = headers[fieldName]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !value.isEmpty
@@ -100,10 +114,7 @@ public func authenticateRequest(
         requireClientAPIKey: requireRegisteredClient
     )
 
-    guard let authorization = request.headers[.authorization]?
-        .trimmingCharacters(in: .whitespacesAndNewlines),
-        !authorization.isEmpty
-    else {
+    guard let authorization = extractAuthorizationHeader(from: request.headers) else {
         throw GatewayError(status: .unauthorized, message: "Missing Authorization header", code: "missing_auth")
     }
 

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -10,19 +10,22 @@ public struct AuthContext: Sendable {
     public let upstreamDpopProof: String?
     /// Resolved official client id when `LATR_GATEWAY_REQUIRE_CLIENT_API_KEY` is enabled.
     public let clientID: String?
+    public let accessTokenSignatureVerified: Bool
 
     public init(
         did: String,
         authorizationHeader: String,
         dpopProof: String,
         upstreamDpopProof: String? = nil,
-        clientID: String? = nil
+        clientID: String? = nil,
+        accessTokenSignatureVerified: Bool = true
     ) {
         self.did = did
         self.authorizationHeader = authorizationHeader
         self.dpopProof = dpopProof
         self.upstreamDpopProof = upstreamDpopProof
         self.clientID = clientID
+        self.accessTokenSignatureVerified = accessTokenSignatureVerified
     }
 }
 
@@ -128,12 +131,15 @@ public func authenticateRequest(
     let dpopJWK = try verifyGatewayDPoP(proof: dpop, accessToken: accessToken, request: request)
 
     let payload: JWTPayload
+    let accessTokenSignatureVerified: Bool
     if let httpClient {
-        payload = try await OAuthTokenVerifier(httpClient: httpClient)
+        let verified = try await OAuthTokenVerifier(httpClient: httpClient)
             .verify(accessToken: accessToken, dpopJWK: dpopJWK)
-            .payload
+        payload = verified.payload
+        accessTokenSignatureVerified = verified.signatureVerified
     } else {
         payload = try decodeJWTPayload(accessToken)
+        accessTokenSignatureVerified = false
         if let jkt = payload.cnf?.jkt {
             guard try jkt == jwkThumbprint(dpopJWK) else {
                 throw GatewayError(status: .unauthorized, message: "Token DPoP key mismatch", code: "invalid_token")
@@ -171,7 +177,8 @@ public func authenticateRequest(
         authorizationHeader: authorization,
         dpopProof: dpop,
         upstreamDpopProof: upstream,
-        clientID: clientID
+        clientID: clientID,
+        accessTokenSignatureVerified: accessTokenSignatureVerified
     )
 }
 

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -128,7 +128,7 @@ public func authenticateRequest(
     let dpopJWK = try verifyGatewayDPoP(proof: dpop, accessToken: accessToken, request: request)
 
     let payload: JWTPayload
-    if let httpClient {
+    if config.oauthVerifyTokenSignature, let httpClient {
         payload = try await OAuthTokenVerifier(httpClient: httpClient)
             .verify(accessToken: accessToken, dpopJWK: dpopJWK)
             .payload

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/AuthContext.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Hummingbird
 import HTTPTypes
+import AsyncHTTPClient
 
 public struct AuthContext: Sendable {
     public let did: String
@@ -87,6 +88,7 @@ public func authenticateRequest(
     _ request: Request,
     config: GatewayConfig,
     store: any DeveloperStore,
+    httpClient: HTTPClient? = nil,
     requireClientAPIKey override: Bool? = nil
 ) async throws -> AuthContext {
     let requireRegisteredClient = resolvesRegisteredClientRequirement(
@@ -116,9 +118,24 @@ public func authenticateRequest(
     guard let dpop = extractDPOPHeader(from: request.headers) else {
         throw GatewayError(status: .unauthorized, message: "Missing DPoP proof header", code: "missing_dpop")
     }
-    try assertDPOPStructure(dpop)
+    let dpopJWK = try verifyGatewayDPoP(proof: dpop, accessToken: accessToken, request: request)
 
-    let payload = try decodeJWTPayload(accessToken)
+    let payload: JWTPayload
+    if let httpClient {
+        payload = try await OAuthTokenVerifier(httpClient: httpClient)
+            .verify(accessToken: accessToken, dpopJWK: dpopJWK)
+            .payload
+    } else {
+        payload = try decodeJWTPayload(accessToken)
+        if let jkt = payload.cnf?.jkt {
+            guard try jkt == jwkThumbprint(dpopJWK) else {
+                throw GatewayError(status: .unauthorized, message: "Token DPoP key mismatch", code: "invalid_token")
+            }
+        } else {
+            throw GatewayError(status: .unauthorized, message: "Token missing DPoP confirmation", code: "invalid_token")
+        }
+    }
+
     guard let did = payload.sub?.trimmingCharacters(in: .whitespacesAndNewlines), did.hasPrefix("did:") else {
         throw GatewayError(status: .unauthorized, message: "Access token sub must be a DID", code: "invalid_sub")
     }

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
@@ -61,7 +61,9 @@ func verifyGatewayDPoP(
     guard payload.htm.uppercased() == request.method.rawValue.uppercased() else {
         throw GatewayError(status: .unauthorized, message: "DPoP method mismatch", code: "invalid_dpop")
     }
-    guard normalizeDPoPURL(payload.htu) == normalizeDPoPURL(gatewayRequestURL(request)) else {
+    guard gatewayRequestURLCandidates(request).contains(where: {
+        normalizeDPoPURL(payload.htu) == normalizeDPoPURL($0)
+    }) else {
         throw GatewayError(status: .unauthorized, message: "DPoP URL mismatch", code: "invalid_dpop")
     }
 
@@ -117,6 +119,15 @@ private func decodeDPoP<T: Decodable>(_ type: T.Type, from data: Data) throws ->
     }
 }
 
+private func gatewayRequestURLCandidates(_ request: Request) -> [String] {
+    var candidates = [gatewayRequestURL(request)]
+    candidates.append(contentsOf: forwardedGatewayRequestURLCandidates(request))
+    if let original = originalRequestURL(request) {
+        candidates.append(original)
+    }
+    return Array(Set(candidates))
+}
+
 private func gatewayRequestURL(_ request: Request) -> String {
     if request.uri.description.hasPrefix("http://") || request.uri.description.hasPrefix("https://") {
         return request.uri.description
@@ -124,6 +135,49 @@ private func gatewayRequestURL(_ request: Request) -> String {
     let scheme = request.head.scheme ?? "http"
     let authority = request.head.authority ?? "localhost"
     return "\(scheme)://\(authority)\(request.uri)"
+}
+
+private func forwardedGatewayRequestURLCandidates(_ request: Request) -> [String] {
+    guard let forwardedHost = firstHeader(request, names: ["X-Forwarded-Host"]),
+          !forwardedHost.isEmpty
+    else {
+        return []
+    }
+    let forwardedProto = firstHeader(request, names: ["X-Forwarded-Proto"]) ?? "https"
+    let path = request.uri.description
+    return [
+        "\(forwardedProto)://\(forwardedHost)\(path)",
+        "\(forwardedProto)://\(forwardedHost)/api/latr-gateway\(path)",
+    ]
+}
+
+private func originalRequestURL(_ request: Request) -> String? {
+    guard let raw = firstHeader(
+        request,
+        names: ["X-Original-URL", "X-Original-URI", "X-Forwarded-URI", "X-Rewrite-URL"]
+    ), !raw.isEmpty else {
+        return nil
+    }
+    if raw.hasPrefix("http://") || raw.hasPrefix("https://") {
+        return raw
+    }
+    let scheme = firstHeader(request, names: ["X-Forwarded-Proto"]) ?? request.head.scheme ?? "https"
+    let authority = firstHeader(request, names: ["X-Forwarded-Host"]) ?? request.head.authority ?? "localhost"
+    return "\(scheme)://\(authority)\(raw.hasPrefix("/") ? raw : "/\(raw)")"
+}
+
+private func firstHeader(_ request: Request, names: [String]) -> String? {
+    for name in names {
+        guard let field = HTTPField.Name(name),
+              let raw = request.headers[field]
+        else { continue }
+        if let value = raw.split(separator: ",").first.map({
+            String($0).trimmingCharacters(in: .whitespacesAndNewlines)
+        }), !value.isEmpty {
+            return value
+        }
+    }
+    return nil
 }
 
 private func normalizeDPoPURL(_ raw: String) -> String? {

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
@@ -1,0 +1,143 @@
+import Crypto
+import Foundation
+import Hummingbird
+import HTTPTypes
+
+struct DPoPJWK: Decodable, Encodable {
+    let kty: String
+    let crv: String
+    let x: String
+    let y: String
+}
+
+private struct DPoPHeader: Decodable {
+    let typ: String?
+    let alg: String
+    let jwk: DPoPJWK
+}
+
+private struct DPoPPayload: Decodable {
+    let htm: String
+    let htu: String
+    let iat: Int
+    let jti: String
+    let ath: String?
+}
+
+private final class DPoPReplayCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen: [String: Int] = [:]
+
+    func insert(_ jti: String, expiresAt: Int, now: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        seen = seen.filter { $0.value >= now }
+        guard seen[jti] == nil else { return false }
+        seen[jti] = expiresAt
+        return true
+    }
+}
+
+private let dpopReplayCache = DPoPReplayCache()
+
+func verifyGatewayDPoP(
+    proof: String,
+    accessToken: String,
+    request: Request,
+    now: Date = Date()
+) throws -> DPoPJWK {
+    let headerData = try jwtSegmentData(proof, segment: 0, code: "invalid_dpop")
+    let payloadData = try jwtSegmentData(proof, segment: 1, code: "invalid_dpop")
+    let header = try decodeDPoP(DPoPHeader.self, from: headerData)
+    let payload = try decodeDPoP(DPoPPayload.self, from: payloadData)
+
+    guard header.typ?.caseInsensitiveCompare("dpop+jwt") == .orderedSame else {
+        throw GatewayError(status: .unauthorized, message: "Invalid DPoP proof type", code: "invalid_dpop")
+    }
+    guard header.alg == "ES256", header.jwk.kty == "EC", header.jwk.crv == "P-256" else {
+        throw GatewayError(status: .unauthorized, message: "Unsupported DPoP key", code: "invalid_dpop")
+    }
+
+    guard payload.htm.uppercased() == request.method.rawValue.uppercased() else {
+        throw GatewayError(status: .unauthorized, message: "DPoP method mismatch", code: "invalid_dpop")
+    }
+    guard normalizeDPoPURL(payload.htu) == normalizeDPoPURL(gatewayRequestURL(request)) else {
+        throw GatewayError(status: .unauthorized, message: "DPoP URL mismatch", code: "invalid_dpop")
+    }
+
+    let nowSeconds = Int(now.timeIntervalSince1970)
+    guard abs(nowSeconds - payload.iat) <= 300 else {
+        throw GatewayError(status: .unauthorized, message: "DPoP proof expired", code: "invalid_dpop")
+    }
+    guard !payload.jti.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+          dpopReplayCache.insert(payload.jti, expiresAt: payload.iat + 300, now: nowSeconds)
+    else {
+        throw GatewayError(status: .unauthorized, message: "DPoP proof replayed", code: "invalid_dpop_replay")
+    }
+
+    let expectedAth = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
+    guard payload.ath == expectedAth else {
+        throw GatewayError(status: .unauthorized, message: "DPoP access token hash mismatch", code: "invalid_dpop")
+    }
+
+    let publicKey = try publicKey(from: header.jwk)
+    let signature = try P256.Signing.ECDSASignature(rawRepresentation: jwtSignature(proof))
+    guard publicKey.isValidSignature(signature, for: try jwtSigningInput(proof)) else {
+        throw GatewayError(status: .unauthorized, message: "Invalid DPoP signature", code: "invalid_dpop")
+    }
+
+    return header.jwk
+}
+
+func jwkThumbprint(_ jwk: DPoPJWK) throws -> String {
+    let canonical = #"{"crv":"\#(jwk.crv)","kty":"\#(jwk.kty)","x":"\#(jwk.x)","y":"\#(jwk.y)"}"#
+    return base64URLEncode(Data(SHA256.hash(data: Data(canonical.utf8))))
+}
+
+private func publicKey(from jwk: DPoPJWK) throws -> P256.Signing.PublicKey {
+    guard let x = base64URLDecode(jwk.x), let y = base64URLDecode(jwk.y), x.count == 32, y.count == 32 else {
+        throw GatewayError(status: .unauthorized, message: "Invalid DPoP public key", code: "invalid_dpop")
+    }
+    return try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+}
+
+private func jwtSegmentData(_ jwt: String, segment: Int, code: String) throws -> Data {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, parts.indices.contains(segment), let data = base64URLDecode(String(parts[segment])) else {
+        throw GatewayError(status: .unauthorized, message: "Malformed DPoP proof", code: code)
+    }
+    return data
+}
+
+private func decodeDPoP<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    do {
+        return try JSONDecoder().decode(T.self, from: data)
+    } catch {
+        throw GatewayError(status: .unauthorized, message: "Malformed DPoP proof", code: "invalid_dpop")
+    }
+}
+
+private func gatewayRequestURL(_ request: Request) -> String {
+    if request.uri.description.hasPrefix("http://") || request.uri.description.hasPrefix("https://") {
+        return request.uri.description
+    }
+    let scheme = request.head.scheme ?? "http"
+    let authority = request.head.authority ?? "localhost"
+    return "\(scheme)://\(authority)\(request.uri)"
+}
+
+private func normalizeDPoPURL(_ raw: String) -> String? {
+    guard var components = URLComponents(string: raw),
+          let scheme = components.scheme?.lowercased(),
+          let host = components.host?.lowercased()
+    else {
+        return nil
+    }
+    components.scheme = scheme
+    components.host = host
+    components.fragment = nil
+    if (scheme == "https" && components.port == 443) || (scheme == "http" && components.port == 80) {
+        components.port = nil
+    }
+    return components.url?.absoluteString
+}

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
@@ -197,6 +197,7 @@ private func normalizeDPoPURL(_ raw: String) -> String? {
     }
     components.scheme = scheme
     components.host = host
+    components.query = nil
     components.fragment = nil
     if (scheme == "https" && components.port == 443) || (scheme == "http" && components.port == 80) {
         components.port = nil

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/DPoPVerifier.swift
@@ -132,9 +132,17 @@ private func gatewayRequestURL(_ request: Request) -> String {
     if request.uri.description.hasPrefix("http://") || request.uri.description.hasPrefix("https://") {
         return request.uri.description
     }
-    let scheme = request.head.scheme ?? "http"
     let authority = request.head.authority ?? "localhost"
+    let scheme = request.head.scheme ?? inferredRequestScheme(forAuthority: authority)
     return "\(scheme)://\(authority)\(request.uri)"
+}
+
+private func inferredRequestScheme(forAuthority authority: String) -> String {
+    let host = authority.split(separator: ":").first.map(String.init) ?? authority
+    if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+        return "http"
+    }
+    return "https"
 }
 
 private func forwardedGatewayRequestURLCandidates(_ request: Request) -> [String] {

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTPayload.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTPayload.swift
@@ -2,10 +2,16 @@ import Foundation
 
 struct JWTPayload: Decodable {
     let sub: String?
+    let iss: String?
     let exp: Int?
     let client_id: String?
     let azp: String?
     let aud: Audience?
+    let cnf: Confirmation?
+
+    struct Confirmation: Decodable {
+        let jkt: String?
+    }
 
     enum Audience: Decodable {
         case single(String)
@@ -31,17 +37,11 @@ struct JWTPayload: Decodable {
 
 func decodeJWTPayload(_ token: String) throws -> JWTPayload {
     let parts = token.split(separator: ".", omittingEmptySubsequences: false)
-    guard parts.count >= 2 else {
+    guard parts.count == 3 else {
         throw GatewayError(status: .unauthorized, message: "Malformed access token", code: "invalid_token")
     }
 
-    var payloadB64 = String(parts[1])
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    let padding = (4 - payloadB64.count % 4) % 4
-    payloadB64.append(String(repeating: "=", count: padding))
-
-    guard let data = Data(base64Encoded: payloadB64) else {
+    guard let data = base64URLDecode(String(parts[1])) else {
         throw GatewayError(
             status: .unauthorized,
             message: "Malformed access token payload",

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTUtilities.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/JWTUtilities.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+func base64URLDecode(_ value: String) -> Data? {
+    var base64 = value
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    let padding = (4 - base64.count % 4) % 4
+    base64.append(String(repeating: "=", count: padding))
+    return Data(base64Encoded: base64)
+}
+
+func base64URLEncode(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+func decodeJWTJSON(_ jwt: String, segment: Int) throws -> [String: Any] {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, parts.indices.contains(segment) else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT", code: "invalid_token")
+    }
+    guard let data = base64URLDecode(String(parts[segment])),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT payload", code: "invalid_token")
+    }
+    return json
+}
+
+func jwtSigningInput(_ jwt: String) throws -> Data {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3 else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT", code: "invalid_token")
+    }
+    return Data("\(parts[0]).\(parts[1])".utf8)
+}
+
+func jwtSignature(_ jwt: String) throws -> Data {
+    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, let signature = base64URLDecode(String(parts[2])) else {
+        throw GatewayError(status: .unauthorized, message: "Malformed JWT signature", code: "invalid_token")
+    }
+    return signature
+}
+
+func jwtClaimString(_ jwt: String, claim: String) -> String? {
+    guard let json = try? decodeJWTJSON(jwt, segment: 1) else { return nil }
+    return json[claim] as? String
+}

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
@@ -30,6 +30,7 @@ private struct OAuthJWK: Decodable {
 
 struct VerifiedOAuthToken: Sendable {
     let payload: JWTPayload
+    let signatureVerified: Bool
 }
 
 public struct OAuthTokenVerifier: Sendable {
@@ -59,7 +60,6 @@ public struct OAuthTokenVerifier: Sendable {
         if let metadataIssuer = metadata.issuer, metadataIssuer != issuer {
             throw GatewayError(status: .unauthorized, message: "Token issuer metadata mismatch", code: "invalid_token")
         }
-        let jwks = try await fetchJWKSet(jwksURI: metadata.jwks_uri)
         guard let expectedKeyType = keyType(for: header.alg) else {
             throw GatewayError(
                 status: .unauthorized,
@@ -67,6 +67,7 @@ public struct OAuthTokenVerifier: Sendable {
                 code: "unsupported_token_alg"
             )
         }
+        let jwks = try await fetchJWKSet(jwksURI: metadata.jwks_uri)
         guard let key = jwks.keys.first(where: { jwk in
             guard jwk.kty == expectedKeyType else { return false }
             guard jwk.alg == nil || jwk.alg == header.alg else { return false }
@@ -74,6 +75,10 @@ public struct OAuthTokenVerifier: Sendable {
             guard let kid = header.kid else { return true }
             return jwk.kid == kid
         }) else {
+            if jwks.keys.isEmpty {
+                try verifyDPoPConfirmation(payload: payload, dpopJWK: dpopJWK)
+                return VerifiedOAuthToken(payload: payload, signatureVerified: false)
+            }
             throw GatewayError(status: .unauthorized, message: "Token signing key not found", code: "invalid_token")
         }
 
@@ -81,6 +86,12 @@ public struct OAuthTokenVerifier: Sendable {
             throw GatewayError(status: .unauthorized, message: "Invalid token signature", code: "invalid_token")
         }
 
+        try verifyDPoPConfirmation(payload: payload, dpopJWK: dpopJWK)
+
+        return VerifiedOAuthToken(payload: payload, signatureVerified: true)
+    }
+
+    private func verifyDPoPConfirmation(payload: JWTPayload, dpopJWK: DPoPJWK) throws {
         if let cnf = payload.cnf, let jkt = cnf.jkt {
             guard try jkt == jwkThumbprint(dpopJWK) else {
                 throw GatewayError(status: .unauthorized, message: "Token DPoP key mismatch", code: "invalid_token")
@@ -88,8 +99,6 @@ public struct OAuthTokenVerifier: Sendable {
         } else {
             throw GatewayError(status: .unauthorized, message: "Token missing DPoP confirmation", code: "invalid_token")
         }
-
-        return VerifiedOAuthToken(payload: payload)
     }
 
     private func decodeJWTHeader(_ token: String) throws -> OAuthTokenHeader {

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
@@ -58,8 +58,15 @@ public struct OAuthTokenVerifier: Sendable {
             throw GatewayError(status: .unauthorized, message: "Token issuer metadata mismatch", code: "invalid_token")
         }
         let jwks = try await fetchJWKSet(jwksURI: metadata.jwks_uri)
+        guard let expectedKeyType = keyType(for: header.alg) else {
+            throw GatewayError(
+                status: .unauthorized,
+                message: "Unsupported token signing algorithm: \(header.alg)",
+                code: "unsupported_token_alg"
+            )
+        }
         guard let key = jwks.keys.first(where: { jwk in
-            guard jwk.kty == keyType(for: header.alg) else { return false }
+            guard jwk.kty == expectedKeyType else { return false }
             guard let kid = header.kid else { return true }
             return jwk.kid == kid
         }) else {
@@ -144,10 +151,10 @@ public struct OAuthTokenVerifier: Sendable {
         }
     }
 
-    private func keyType(for alg: String) -> String {
+    private func keyType(for alg: String) -> String? {
         switch alg {
         case "ES256": "EC"
-        default: ""
+        default: nil
         }
     }
 }

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
@@ -1,6 +1,7 @@
 import AsyncHTTPClient
 import Crypto
 import Foundation
+import P256K
 
 private struct OAuthTokenHeader: Decodable {
     let alg: String
@@ -19,6 +20,7 @@ private struct JWKSet: Decodable {
 private struct OAuthJWK: Decodable {
     let kty: String
     let kid: String?
+    let alg: String?
     let crv: String?
     let x: String?
     let y: String?
@@ -67,6 +69,8 @@ public struct OAuthTokenVerifier: Sendable {
         }
         guard let key = jwks.keys.first(where: { jwk in
             guard jwk.kty == expectedKeyType else { return false }
+            guard jwk.alg == nil || jwk.alg == header.alg else { return false }
+            guard jwk.curveSupports(alg: header.alg) else { return false }
             guard let kid = header.kid else { return true }
             return jwk.kid == kid
         }) else {
@@ -135,8 +139,7 @@ public struct OAuthTokenVerifier: Sendable {
         let signature = try jwtSignature(jwt)
         switch header.alg {
         case "ES256":
-            guard key.crv == "P-256",
-                  let x = key.x.flatMap(base64URLDecode),
+            guard let x = key.x.flatMap(base64URLDecode),
                   let y = key.y.flatMap(base64URLDecode),
                   x.count == 32,
                   y.count == 32
@@ -146,6 +149,18 @@ public struct OAuthTokenVerifier: Sendable {
             let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
             let ecdsa = try P256.Signing.ECDSASignature(rawRepresentation: signature)
             return publicKey.isValidSignature(ecdsa, for: signingInput)
+        case "ES256K":
+            guard let x = key.x.flatMap(base64URLDecode),
+                  let y = key.y.flatMap(base64URLDecode),
+                  x.count == 32,
+                  y.count == 32,
+                  signature.count == 64
+            else {
+                return false
+            }
+            let publicKey = try P256K.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+            let ecdsa = try P256K.Signing.ECDSASignature(compactRepresentation: signature)
+            return publicKey.isValidSignature(ecdsa, for: signingInput)
         default:
             return false
         }
@@ -153,8 +168,21 @@ public struct OAuthTokenVerifier: Sendable {
 
     private func keyType(for alg: String) -> String? {
         switch alg {
-        case "ES256": "EC"
+        case "ES256", "ES256K": "EC"
         default: nil
+        }
+    }
+}
+
+private extension OAuthJWK {
+    func curveSupports(alg: String) -> Bool {
+        switch alg {
+        case "ES256":
+            crv == "P-256"
+        case "ES256K":
+            crv == "secp256k1"
+        default:
+            false
         }
     }
 }

--- a/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Auth/OAuthTokenVerifier.swift
@@ -1,0 +1,153 @@
+import AsyncHTTPClient
+import Crypto
+import Foundation
+
+private struct OAuthTokenHeader: Decodable {
+    let alg: String
+    let kid: String?
+}
+
+private struct OAuthAuthorizationServerMetadata: Decodable {
+    let issuer: String?
+    let jwks_uri: String
+}
+
+private struct JWKSet: Decodable {
+    let keys: [OAuthJWK]
+}
+
+private struct OAuthJWK: Decodable {
+    let kty: String
+    let kid: String?
+    let crv: String?
+    let x: String?
+    let y: String?
+    let n: String?
+    let e: String?
+}
+
+struct VerifiedOAuthToken: Sendable {
+    let payload: JWTPayload
+}
+
+public struct OAuthTokenVerifier: Sendable {
+    private let httpClient: HTTPClient
+    private let fetchData: (@Sendable (URL) async throws -> Data)?
+
+    public init(
+        httpClient: HTTPClient,
+        fetchData: (@Sendable (URL) async throws -> Data)? = nil
+    ) {
+        self.httpClient = httpClient
+        self.fetchData = fetchData
+    }
+
+    func verify(accessToken: String, dpopJWK: DPoPJWK) async throws -> VerifiedOAuthToken {
+        let header = try decodeJWTHeader(accessToken)
+        let payload = try decodeJWTPayload(accessToken)
+        guard let issuer = payload.iss?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let issuerURL = URL(string: issuer),
+              issuerURL.scheme == "https",
+              issuerURL.host?.isEmpty == false
+        else {
+            throw GatewayError(status: .unauthorized, message: "Missing token issuer", code: "invalid_token")
+        }
+
+        let metadata = try await fetchAuthorizationServerMetadata(issuerURL: issuerURL)
+        if let metadataIssuer = metadata.issuer, metadataIssuer != issuer {
+            throw GatewayError(status: .unauthorized, message: "Token issuer metadata mismatch", code: "invalid_token")
+        }
+        let jwks = try await fetchJWKSet(jwksURI: metadata.jwks_uri)
+        guard let key = jwks.keys.first(where: { jwk in
+            guard jwk.kty == keyType(for: header.alg) else { return false }
+            guard let kid = header.kid else { return true }
+            return jwk.kid == kid
+        }) else {
+            throw GatewayError(status: .unauthorized, message: "Token signing key not found", code: "invalid_token")
+        }
+
+        guard try verifyJWTSignature(jwt: accessToken, header: header, key: key) else {
+            throw GatewayError(status: .unauthorized, message: "Invalid token signature", code: "invalid_token")
+        }
+
+        if let cnf = payload.cnf, let jkt = cnf.jkt {
+            guard try jkt == jwkThumbprint(dpopJWK) else {
+                throw GatewayError(status: .unauthorized, message: "Token DPoP key mismatch", code: "invalid_token")
+            }
+        } else {
+            throw GatewayError(status: .unauthorized, message: "Token missing DPoP confirmation", code: "invalid_token")
+        }
+
+        return VerifiedOAuthToken(payload: payload)
+    }
+
+    private func decodeJWTHeader(_ token: String) throws -> OAuthTokenHeader {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let data = base64URLDecode(String(parts[0]))
+        else {
+            throw GatewayError(status: .unauthorized, message: "Malformed access token", code: "invalid_token")
+        }
+        do {
+            return try JSONDecoder().decode(OAuthTokenHeader.self, from: data)
+        } catch {
+            throw GatewayError(status: .unauthorized, message: "Malformed access token header", code: "invalid_token")
+        }
+    }
+
+    private func fetchAuthorizationServerMetadata(issuerURL: URL) async throws -> OAuthAuthorizationServerMetadata {
+        let metadataURL = issuerURL.appendingPathComponent(".well-known/oauth-authorization-server")
+        let data = try await fetch(metadataURL)
+        return try JSONDecoder().decode(OAuthAuthorizationServerMetadata.self, from: data)
+    }
+
+    private func fetchJWKSet(jwksURI: String) async throws -> JWKSet {
+        guard let url = URL(string: jwksURI), url.scheme == "https", url.host?.isEmpty == false else {
+            throw GatewayError(status: .unauthorized, message: "Invalid token JWKS URI", code: "invalid_token")
+        }
+        let data = try await fetch(url)
+        return try JSONDecoder().decode(JWKSet.self, from: data)
+    }
+
+    private func fetch(_ url: URL) async throws -> Data {
+        if let fetchData {
+            return try await fetchData(url)
+        }
+        var request = HTTPClientRequest(url: url.absoluteString)
+        request.headers.add(name: "Accept", value: "application/json")
+        let response = try await httpClient.execute(request, timeout: .seconds(10))
+        guard response.status == .ok else {
+            throw GatewayError(status: .unauthorized, message: "Token metadata lookup failed", code: "invalid_token")
+        }
+        let body = try await response.body.collect(upTo: 1_048_576)
+        return Data(buffer: body)
+    }
+
+    private func verifyJWTSignature(jwt: String, header: OAuthTokenHeader, key: OAuthJWK) throws -> Bool {
+        let signingInput = try jwtSigningInput(jwt)
+        let signature = try jwtSignature(jwt)
+        switch header.alg {
+        case "ES256":
+            guard key.crv == "P-256",
+                  let x = key.x.flatMap(base64URLDecode),
+                  let y = key.y.flatMap(base64URLDecode),
+                  x.count == 32,
+                  y.count == 32
+            else {
+                return false
+            }
+            let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+            let ecdsa = try P256.Signing.ECDSASignature(rawRepresentation: signature)
+            return publicKey.isValidSignature(ecdsa, for: signingInput)
+        default:
+            return false
+        }
+    }
+
+    private func keyType(for alg: String) -> String {
+        switch alg {
+        case "ES256": "EC"
+        default: ""
+        }
+    }
+}

--- a/services/latr-gateway/Sources/LatrGatewayLib/Config/GatewayConfig.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Config/GatewayConfig.swift
@@ -5,6 +5,7 @@ public struct GatewayConfig: Sendable {
     public let appEnv: AppEnvironment
     public let plcURL: String
     public let oauthRequireKnownClient: Bool
+    public let oauthVerifyTokenSignature: Bool
     public let requireClientAPIKey: Bool
     public let officialClientCredentials: [String: String]
     public let clientRegistryURL: URL
@@ -27,6 +28,7 @@ public struct GatewayConfig: Sendable {
         appEnv: AppEnvironment,
         plcURL: String,
         oauthRequireKnownClient: Bool,
+        oauthVerifyTokenSignature: Bool? = nil,
         requireClientAPIKey: Bool = false,
         officialClientCredentials: [String: String] = [:],
         clientRegistryURL: URL = GatewayConfig.defaultClientRegistryURL(),
@@ -42,6 +44,7 @@ public struct GatewayConfig: Sendable {
         self.appEnv = appEnv
         self.plcURL = plcURL
         self.oauthRequireKnownClient = oauthRequireKnownClient
+        self.oauthVerifyTokenSignature = oauthVerifyTokenSignature ?? (appEnv == .prod)
         self.requireClientAPIKey = requireClientAPIKey
         self.officialClientCredentials = officialClientCredentials
         self.clientRegistryURL = clientRegistryURL
@@ -101,6 +104,13 @@ public struct GatewayConfig: Sendable {
             requireClientAPIKey = appEnv == .prod
         }
 
+        let verifyTokenSignature: Bool
+        if let raw = env["OAUTH_TOKEN_VERIFY_SIGNATURE"] {
+            verifyTokenSignature = parseBool(raw)
+        } else {
+            verifyTokenSignature = appEnv == .prod
+        }
+
         let officialClientCredentials = parseOfficialClientCredentials(
             env["LATR_GATEWAY_OFFICIAL_CLIENT_CREDENTIALS"]
         )
@@ -130,6 +140,7 @@ public struct GatewayConfig: Sendable {
             appEnv: appEnv,
             plcURL: plcURL,
             oauthRequireKnownClient: requireKnown,
+            oauthVerifyTokenSignature: verifyTokenSignature,
             requireClientAPIKey: requireClientAPIKey,
             officialClientCredentials: officialClientCredentials,
             clientRegistryURL: clientRegistryURL,

--- a/services/latr-gateway/Sources/LatrGatewayLib/Config/GatewayConfig.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Config/GatewayConfig.swift
@@ -5,7 +5,6 @@ public struct GatewayConfig: Sendable {
     public let appEnv: AppEnvironment
     public let plcURL: String
     public let oauthRequireKnownClient: Bool
-    public let oauthVerifyTokenSignature: Bool
     public let requireClientAPIKey: Bool
     public let officialClientCredentials: [String: String]
     public let clientRegistryURL: URL
@@ -28,7 +27,6 @@ public struct GatewayConfig: Sendable {
         appEnv: AppEnvironment,
         plcURL: String,
         oauthRequireKnownClient: Bool,
-        oauthVerifyTokenSignature: Bool? = nil,
         requireClientAPIKey: Bool = false,
         officialClientCredentials: [String: String] = [:],
         clientRegistryURL: URL = GatewayConfig.defaultClientRegistryURL(),
@@ -44,7 +42,6 @@ public struct GatewayConfig: Sendable {
         self.appEnv = appEnv
         self.plcURL = plcURL
         self.oauthRequireKnownClient = oauthRequireKnownClient
-        self.oauthVerifyTokenSignature = oauthVerifyTokenSignature ?? (appEnv == .prod)
         self.requireClientAPIKey = requireClientAPIKey
         self.officialClientCredentials = officialClientCredentials
         self.clientRegistryURL = clientRegistryURL
@@ -104,13 +101,6 @@ public struct GatewayConfig: Sendable {
             requireClientAPIKey = appEnv == .prod
         }
 
-        let verifyTokenSignature: Bool
-        if let raw = env["OAUTH_TOKEN_VERIFY_SIGNATURE"] {
-            verifyTokenSignature = parseBool(raw)
-        } else {
-            verifyTokenSignature = appEnv == .prod
-        }
-
         let officialClientCredentials = parseOfficialClientCredentials(
             env["LATR_GATEWAY_OFFICIAL_CLIENT_CREDENTIALS"]
         )
@@ -140,7 +130,6 @@ public struct GatewayConfig: Sendable {
             appEnv: appEnv,
             plcURL: plcURL,
             oauthRequireKnownClient: requireKnown,
-            oauthVerifyTokenSignature: verifyTokenSignature,
             requireClientAPIKey: requireClientAPIKey,
             officialClientCredentials: officialClientCredentials,
             clientRegistryURL: clientRegistryURL,

--- a/services/latr-gateway/Sources/LatrGatewayLib/Developer/DeveloperRoutes.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Developer/DeveloperRoutes.swift
@@ -1,3 +1,4 @@
+import AsyncHTTPClient
 import Foundation
 import Hummingbird
 
@@ -127,7 +128,12 @@ private func handleDeveloper(
     handler: (AuthContext) async throws -> Response
 ) async -> Response {
     do {
-        let auth = try await authenticateDeveloperRequest(request, config: services.config, store: services.developerStore)
+        let auth = try await authenticateDeveloperRequest(
+            request,
+            config: services.config,
+            store: services.developerStore,
+            httpClient: services.httpClient
+        )
         return try await handler(auth)
     } catch {
         return errorResponse(error)
@@ -137,12 +143,14 @@ private func handleDeveloper(
 private func authenticateDeveloperRequest(
     _ request: Request,
     config: GatewayConfig,
-    store: any DeveloperStore
+    store: any DeveloperStore,
+    httpClient: HTTPClient
 ) async throws -> AuthContext {
     try await authenticateRequest(
         request,
         config: config,
         store: store,
+        httpClient: httpClient,
         requireClientAPIKey: false
     )
 }

--- a/services/latr-gateway/Sources/LatrGatewayLib/Developer/DeveloperRoutes.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Developer/DeveloperRoutes.swift
@@ -134,6 +134,13 @@ private func handleDeveloper(
             store: services.developerStore,
             httpClient: services.httpClient
         )
+        guard auth.accessTokenSignatureVerified else {
+            throw GatewayError(
+                status: .unauthorized,
+                message: "Access token signature could not be verified for developer routes",
+                code: "invalid_token"
+            )
+        }
         return try await handler(auth)
     } catch {
         return errorResponse(error)

--- a/services/latr-gateway/Sources/LatrGatewayLib/HTTP/CorsMiddleware.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/HTTP/CorsMiddleware.swift
@@ -28,7 +28,7 @@ public struct CorsMiddleware<Context: RequestContext>: RouterMiddleware {
         headers[.accessControlAllowOrigin] = origin
         headers[.accessControlAllowMethods] = "GET, POST, PATCH, DELETE, OPTIONS"
         headers[.accessControlAllowHeaders] =
-            "Authorization, Content-Type, DPoP, X-ATProto-Upstream-DPoP, X-Latr-Official-Client, X-Latr-Client-Id, X-Latr-API-Key"
+            "Authorization, Content-Type, DPoP, X-ATProto-Upstream-DPoP, X-Latr-Forwarded-Authorization, X-Latr-Forwarded-DPoP, X-Latr-Official-Client, X-Latr-Client-Id, X-Latr-API-Key"
         headers[.vary] = "Origin"
         return headers
     }

--- a/services/latr-gateway/Sources/LatrGatewayLib/PDS/PDSRepoClient.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/PDS/PDSRepoClient.swift
@@ -262,10 +262,27 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
         collection: LexiconCollection,
         withKey key: String
     ) async throws -> RepositoryRecord<Value>? where Value: Codable & Sendable {
+        try await record(in: repository, collection: collection, withKey: key, useAuth: false)
+    }
+
+    public func authenticatedRecord<Value>(
+        in repository: String,
+        collection: LexiconCollection,
+        withKey key: String
+    ) async throws -> RepositoryRecord<Value>? where Value: Codable & Sendable {
+        try await record(in: repository, collection: collection, withKey: key, useAuth: true)
+    }
+
+    private func record<Value>(
+        in repository: String,
+        collection: LexiconCollection,
+        withKey key: String,
+        useAuth: Bool
+    ) async throws -> RepositoryRecord<Value>? where Value: Codable & Sendable {
         let json = try await xrpcGet(
             method: "com.atproto.repo.getRecord",
             query: ["repo": repository, "collection": collection.identifier, "rkey": key],
-            useAuth: false
+            useAuth: useAuth
         )
         guard let uri = json["uri"] as? String,
               let cid = json["cid"] as? String,

--- a/services/latr-gateway/Sources/LatrGatewayLib/PDS/PDSRepoClient.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/PDS/PDSRepoClient.swift
@@ -77,12 +77,12 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
         let requestURL: String
         let dpopProof: String
         let usedUpstreamProof: Bool
-        if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "POST") {
+        let base = try await pdsBase()
+        if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "POST", pdsBase: base) {
             requestURL = consumed.url
             dpopProof = consumed.proof
             usedUpstreamProof = true
         } else {
-            let base = try await pdsBase()
             requestURL = "\(base)/xrpc/\(method)"
             dpopProof = auth.dpopProof
             usedUpstreamProof = false
@@ -151,17 +151,16 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
     private func xrpcGet(method: String, query: [String: String], useAuth: Bool) async throws -> [String: Any] {
         let xrpcBaseURL: String
         let dpopProof: String?
+        let base = try await pdsBase()
         if useAuth {
-            if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "GET") {
+            if let consumed = upstreamPool.consume(forXrpcMethod: method, httpMethod: "GET", pdsBase: base) {
                 xrpcBaseURL = consumed.url
                 dpopProof = consumed.proof
             } else {
-                let base = try await pdsBase()
                 xrpcBaseURL = "\(base)/xrpc/\(method)"
                 dpopProof = auth.dpopProof
             }
         } else {
-            let base = try await pdsBase()
             xrpcBaseURL = "\(base)/xrpc/\(method)"
             dpopProof = nil
         }
@@ -348,4 +347,3 @@ public struct PDSRepositoryClient: RepositoryClient, Sendable {
         )
     }
 }
-

--- a/services/latr-gateway/Sources/LatrGatewayLib/PDS/UpstreamProofPool.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/PDS/UpstreamProofPool.swift
@@ -15,10 +15,11 @@ final class UpstreamProofPool: @unchecked Sendable {
         }
     }
 
-    func consume(forXrpcMethod method: String, httpMethod: String) -> (proof: String, url: String)? {
+    func consume(forXrpcMethod method: String, httpMethod: String, pdsBase: String) -> (proof: String, url: String)? {
         lock.lock()
         defer { lock.unlock() }
 
+        let normalizedPDSBase = pdsBase.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         for (index, proof) in proofs.enumerated() {
             guard let htu = decodeJWTClaimString(proof, claim: "htu"),
                   let htm = decodeJWTClaimString(proof, claim: "htm"),
@@ -28,6 +29,7 @@ final class UpstreamProofPool: @unchecked Sendable {
             }
 
             let normalized = htu.split(separator: "?").first.map(String.init) ?? htu
+            guard normalized.hasPrefix("\(normalizedPDSBase)/xrpc/") else { continue }
             guard normalized.hasSuffix("/xrpc/\(method)") else { continue }
 
             proofs.remove(at: index)
@@ -39,16 +41,7 @@ final class UpstreamProofPool: @unchecked Sendable {
 }
 
 private func decodeJWTClaimString(_ jwt: String, claim: String) -> String? {
-    let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
-    guard parts.count >= 2 else { return nil }
-
-    var payloadB64 = String(parts[1])
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    let padding = (4 - payloadB64.count % 4) % 4
-    payloadB64.append(String(repeating: "=", count: padding))
-
-    guard let data = Data(base64Encoded: payloadB64),
+    guard let data = base64URLDecode(String(jwt.split(separator: ".", omittingEmptySubsequences: false).dropFirst().first ?? "")),
           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
           let value = json[claim] as? String
     else {

--- a/services/latr-gateway/Sources/LatrGatewayLib/Routes/AppRouter.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Routes/AppRouter.swift
@@ -143,7 +143,16 @@ public func buildRouter(services: GatewayServices) -> Router<BasicRequestContext
 
             let library = services.savedLibrary(for: auth)
             let key = RecordKey.key(forSubjectURI: subjectURI)
-            let record = try await library.savedItem(withKey: key)
+            let record: RepositoryRecord<SavedItem>?
+            if auth.accessTokenSignatureVerified {
+                record = try await library.savedItem(withKey: key)
+            } else {
+                record = try await services.repositoryClient(for: auth).authenticatedRecord(
+                    in: auth.did,
+                    collection: .savedItem,
+                    withKey: key
+                )
+            }
             return try jsonResponse(SavedItemLookupResponse(record: record))
         }
     }
@@ -263,6 +272,7 @@ private func handleProtected(
             store: services.developerStore,
             httpClient: services.httpClient
         )
+        try requireLocallyVerifiedTokenIfNeeded(auth: auth, path: request.uri.path)
         if let clientID = auth.clientID {
             try await services.developerStore.assertWithinDailyLimit(clientID: clientID)
         }
@@ -276,5 +286,17 @@ private func handleProtected(
         return response
     } catch {
         return errorResponse(error)
+    }
+}
+
+private func requireLocallyVerifiedTokenIfNeeded(auth: AuthContext, path: String) throws {
+    guard !auth.accessTokenSignatureVerified else { return }
+
+    if path.contains("/og-preview") || path.contains("/discover/at-uri") {
+        throw GatewayError(
+            status: .unauthorized,
+            message: "Access token signature could not be verified for this route",
+            code: "invalid_token"
+        )
     }
 }

--- a/services/latr-gateway/Sources/LatrGatewayLib/Routes/AppRouter.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/Routes/AppRouter.swift
@@ -260,7 +260,8 @@ private func handleProtected(
         let auth = try await authenticateRequest(
             request,
             config: services.config,
-            store: services.developerStore
+            store: services.developerStore,
+            httpClient: services.httpClient
         )
         if let clientID = auth.clientID {
             try await services.developerStore.assertWithinDailyLimit(clientID: clientID)

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -2,6 +2,7 @@ import AsyncHTTPClient
 import Crypto
 import Foundation
 import Hummingbird
+import HTTPTypes
 @testable import LatrGatewayLib
 import NIOCore
 import XCTest
@@ -45,6 +46,33 @@ final class AuthVerificationTests: XCTestCase {
         )
     }
 
+    func testDPoPAcceptsForwardedProxyPrefixForSameGatewayRoute() throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let proof = try signedDPoP(
+            signingKey: key,
+            jwk: jwk,
+            htm: "GET",
+            htu: "https://testing.latr.link/api/latr-gateway/v1/latr/saves",
+            accessToken: token
+        )
+
+        XCTAssertNoThrow(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(
+                    path: "/v1/latr/saves",
+                    headers: [
+                        HTTPField.Name("X-Forwarded-Host")!: "testing.latr.link",
+                        HTTPField.Name("X-Forwarded-Proto")!: "https",
+                    ]
+                )
+            )
+        )
+    }
+
     func testOAuthVerifierRejectsTamperedAccessTokenSignature() async throws {
         let key = P256.Signing.PrivateKey()
         let jwk = jwk(for: key.publicKey)
@@ -72,13 +100,14 @@ final class AuthVerificationTests: XCTestCase {
         try await httpClient.shutdown()
     }
 
-    private func request(path: String) -> Request {
+    private func request(path: String, headers: HTTPFields = [:]) -> Request {
         Request(
             head: HTTPRequest(
                 method: .get,
                 scheme: "https",
                 authority: "api.testing.latr.link",
-                path: path
+                path: path,
+                headerFields: headers
             ),
             body: RequestBody(buffer: ByteBuffer())
         )
@@ -113,7 +142,8 @@ final class AuthVerificationTests: XCTestCase {
     ) throws -> String {
         let header = #"{"typ":"dpop+jwt","alg":"ES256","jwk":{"kty":"EC","crv":"P-256","x":"\#(jwk.x)","y":"\#(jwk.y)"}}"#
         let ath = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
-        let payload = #"{"htm":"\#(htm)","htu":"\#(htu)","iat":1782860400,"jti":"\#(UUID().uuidString)","ath":"\#(ath)"}"#
+        let iat = Int(Date().timeIntervalSince1970)
+        let payload = #"{"htm":"\#(htm)","htu":"\#(htu)","iat":\#(iat),"jti":"\#(UUID().uuidString)","ath":"\#(ath)"}"#
         return try signJWT(header: header, payload: payload, signingKey: signingKey)
     }
 

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -98,6 +98,31 @@ final class AuthVerificationTests: XCTestCase {
         )
     }
 
+    func testDPoPAcceptsProofURLWithoutQueryString() throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let proof = try signedDPoP(
+            signingKey: key,
+            jwk: jwk,
+            htm: "GET",
+            htu: "https://api.testing.latr.link/v1/latr/og-preview",
+            accessToken: token
+        )
+
+        XCTAssertNoThrow(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(
+                    path: "/v1/latr/og-preview?url=https%3A%2F%2Fexample.com",
+                    scheme: nil,
+                    authority: "api.testing.latr.link"
+                )
+            )
+        )
+    }
+
     func testOAuthVerifierRejectsTamperedAccessTokenSignature() async throws {
         let key = P256.Signing.PrivateKey()
         let jwk = jwk(for: key.publicKey)

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -73,6 +73,31 @@ final class AuthVerificationTests: XCTestCase {
         )
     }
 
+    func testDPoPAcceptsHostedAuthorityWhenSchemeIsMissing() throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let proof = try signedDPoP(
+            signingKey: key,
+            jwk: jwk,
+            htm: "GET",
+            htu: "https://api.testing.latr.link/v1/latr/saves",
+            accessToken: token
+        )
+
+        XCTAssertNoThrow(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(
+                    path: "/v1/latr/saves",
+                    scheme: nil,
+                    authority: "api.testing.latr.link"
+                )
+            )
+        )
+    }
+
     func testOAuthVerifierRejectsTamperedAccessTokenSignature() async throws {
         let key = P256.Signing.PrivateKey()
         let jwk = jwk(for: key.publicKey)
@@ -100,12 +125,17 @@ final class AuthVerificationTests: XCTestCase {
         try await httpClient.shutdown()
     }
 
-    private func request(path: String, headers: HTTPFields = [:]) -> Request {
+    private func request(
+        path: String,
+        scheme: String? = "https",
+        authority: String? = "api.testing.latr.link",
+        headers: HTTPFields = [:]
+    ) -> Request {
         Request(
             head: HTTPRequest(
                 method: .get,
-                scheme: "https",
-                authority: "api.testing.latr.link",
+                scheme: scheme,
+                authority: authority,
                 path: path,
                 headerFields: headers
             ),

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -8,6 +8,29 @@ import NIOCore
 import XCTest
 
 final class AuthVerificationTests: XCTestCase {
+    func testAuthExtractorsAcceptForwardedProxyHeaders() throws {
+        var headers = HTTPFields()
+        headers[HTTPField.Name(forwardedAuthorizationHeader)!] = "DPoP forwarded-token"
+        headers[HTTPField.Name(forwardedDPOPHeader)!] = "forwarded.dpop.jwt"
+
+        XCTAssertEqual(
+            extractAuthorizationHeader(from: headers),
+            "DPoP forwarded-token"
+        )
+        XCTAssertEqual(extractDPOPHeader(from: headers), "forwarded.dpop.jwt")
+    }
+
+    func testAuthExtractorsPreferStandardHeadersOverForwardedProxyHeaders() throws {
+        var headers = HTTPFields()
+        headers[.authorization] = "DPoP standard-token"
+        headers[HTTPField.Name(forwardedAuthorizationHeader)!] = "DPoP forwarded-token"
+        headers[HTTPField.Name("DPoP")!] = "standard.dpop.jwt"
+        headers[HTTPField.Name(forwardedDPOPHeader)!] = "forwarded.dpop.jwt"
+
+        XCTAssertEqual(extractAuthorizationHeader(from: headers), "DPoP standard-token")
+        XCTAssertEqual(extractDPOPHeader(from: headers), "standard.dpop.jwt")
+    }
+
     func testDPoPRejectsUnsignedProofThatUsedToPassStructureCheck() throws {
         let token = unsignedAccessToken()
         let proof = unsignedProof(

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -192,6 +192,34 @@ final class AuthVerificationTests: XCTestCase {
         try await httpClient.shutdown()
     }
 
+    func testOAuthVerifierReportsUnsupportedES256KTokens() async throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try unsupportedES256KAccessToken(dpopJWK: jwk)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","crv":"secp256k1","x":"test","y":"test"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
+            _ = try await verifier.verify(accessToken: token, dpopJWK: jwk)
+            XCTFail("ES256K token verification should fail until secp256k1 support is added")
+        } catch let error as GatewayError {
+            XCTAssertEqual(error.code, "unsupported_token_alg")
+        }
+        try await httpClient.shutdown()
+    }
+
     private func request(
         path: String,
         scheme: String? = "https",
@@ -228,6 +256,13 @@ final class AuthVerificationTests: XCTestCase {
         let jkt = try jwkThumbprint(dpopJWK)
         let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
         return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func unsupportedES256KAccessToken(dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"ES256K"}"#
+        let jkt = try jwkThumbprint(dpopJWK)
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
+        return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
     }
 
     private func signedDPoP(

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -5,6 +5,7 @@ import Hummingbird
 import HTTPTypes
 @testable import LatrGatewayLib
 import NIOCore
+import P256K
 import XCTest
 
 final class AuthVerificationTests: XCTestCase {
@@ -192,10 +193,14 @@ final class AuthVerificationTests: XCTestCase {
         try await httpClient.shutdown()
     }
 
-    func testOAuthVerifierReportsUnsupportedES256KTokens() async throws {
-        let key = P256.Signing.PrivateKey()
-        let jwk = jwk(for: key.publicKey)
-        let token = try unsupportedES256KAccessToken(dpopJWK: jwk)
+    func testOAuthVerifierAcceptsES256KAccessTokens() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessToken(signingKey: signingKey, dpopJWK: dpopJWK)
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         let verifier = OAuthTokenVerifier(
             httpClient: httpClient,
@@ -204,7 +209,39 @@ final class AuthVerificationTests: XCTestCase {
                     return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
                 }
                 if url.absoluteString == "https://auth.example/jwks.json" {
-                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","crv":"secp256k1","x":"test","y":"test"}]}"#
+                    let jwk = es256kJWK(for: signingKey.publicKey)
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","alg":"ES256K","crv":"secp256k1","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        let verified = try await verifier.verify(accessToken: token, dpopJWK: dpopJWK)
+
+        XCTAssertEqual(verified.payload.sub, "did:plc:test")
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierRejectsTamperedES256KAccessTokens() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessToken(signingKey: signingKey, dpopJWK: dpopJWK)
+        let tampered = "\(token)a"
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwk = es256kJWK(for: signingKey.publicKey)
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","alg":"ES256K","crv":"secp256k1","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
                     return Data(jwks.utf8)
                 }
                 throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
@@ -212,8 +249,68 @@ final class AuthVerificationTests: XCTestCase {
         )
 
         do {
+            _ = try await verifier.verify(accessToken: tampered, dpopJWK: dpopJWK)
+            XCTFail("tampered ES256K token should fail verification")
+        } catch let error as GatewayError {
+            XCTAssertEqual(error.code, "invalid_token")
+        }
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierRejectsES256KTokenWithoutDPoPConfirmation() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessTokenWithoutDPoPConfirmation(signingKey: signingKey)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwk = es256kJWK(for: signingKey.publicKey)
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","alg":"ES256K","crv":"secp256k1","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
+            _ = try await verifier.verify(accessToken: token, dpopJWK: dpopJWK)
+            XCTFail("ES256K token without cnf.jkt should fail verification")
+        } catch let error as GatewayError {
+            XCTAssertEqual(error.message, "Token missing DPoP confirmation")
+        }
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierReportsUnsupportedAccessTokenAlgorithms() async throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try unsupportedAccessToken(alg: "EdDSA", dpopJWK: jwk)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    return Data(#"{"keys":[]}"#.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
             _ = try await verifier.verify(accessToken: token, dpopJWK: jwk)
-            XCTFail("ES256K token verification should fail until secp256k1 support is added")
+            XCTFail("unsupported token algorithm should fail verification")
         } catch let error as GatewayError {
             XCTAssertEqual(error.code, "unsupported_token_alg")
         }
@@ -258,8 +355,21 @@ final class AuthVerificationTests: XCTestCase {
         return try signJWT(header: header, payload: payload, signingKey: signingKey)
     }
 
-    private func unsupportedES256KAccessToken(dpopJWK: DPoPJWK) throws -> String {
-        let header = #"{"typ":"at+jwt","alg":"ES256K"}"#
+    private func signedES256KAccessToken(signingKey: P256K.Signing.PrivateKey, dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"ES256K","kid":"test-key"}"#
+        let jkt = try jwkThumbprint(dpopJWK)
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func signedES256KAccessTokenWithoutDPoPConfirmation(signingKey: P256K.Signing.PrivateKey) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"ES256K","kid":"test-key"}"#
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func unsupportedAccessToken(alg: String, dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"typ":"at+jwt","alg":"\#(alg)","kid":"test-key"}"#
         let jkt = try jwkThumbprint(dpopJWK)
         let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
         return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
@@ -285,6 +395,12 @@ final class AuthVerificationTests: XCTestCase {
         return "\(signingInput).\(base64URLEncode(signature))"
     }
 
+    private func signJWT(header: String, payload: String, signingKey: P256K.Signing.PrivateKey) throws -> String {
+        let signingInput = "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8)))"
+        let signature = signingKey.signature(for: Data(signingInput.utf8)).compactRepresentation
+        return "\(signingInput).\(base64URLEncode(signature))"
+    }
+
     private func jwk(for publicKey: P256.Signing.PublicKey) -> DPoPJWK {
         let raw = publicKey.x963Representation
         return DPoPJWK(
@@ -293,5 +409,26 @@ final class AuthVerificationTests: XCTestCase {
             x: base64URLEncode(raw.dropFirst().prefix(32)),
             y: base64URLEncode(raw.dropFirst(33).prefix(32))
         )
+    }
+}
+
+private func es256kJWK(for publicKey: P256K.Signing.PublicKey) -> (x: String, y: String) {
+    let raw = publicKey.uncompressedRepresentation
+    return (
+        x: base64URLEncode(raw.dropFirst().prefix(32)),
+        y: base64URLEncode(raw.dropFirst(33).prefix(32))
+    )
+}
+
+private extension Data {
+    init(hex: String) {
+        var bytes: [UInt8] = []
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            bytes.append(UInt8(hex[index..<nextIndex], radix: 16)!)
+            index = nextIndex
+        }
+        self.init(bytes)
     }
 }

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -12,12 +12,31 @@ final class AuthVerificationTests: XCTestCase {
         var headers = HTTPFields()
         headers[HTTPField.Name(forwardedAuthorizationHeader)!] = "DPoP forwarded-token"
         headers[HTTPField.Name(forwardedDPOPHeader)!] = "forwarded.dpop.jwt"
+        headers[HTTPField.Name(upstreamDPOPHeader)!] = "upstream.dpop.jwt"
 
         XCTAssertEqual(
             extractAuthorizationHeader(from: headers),
             "DPoP forwarded-token"
         )
         XCTAssertEqual(extractDPOPHeader(from: headers), "forwarded.dpop.jwt")
+        XCTAssertEqual(extractUpstreamDPOPHeader(from: headers), "upstream.dpop.jwt")
+    }
+
+    func testAuthExtractorsAcceptLowercaseForwardedProxyHeaders() throws {
+        var headers = HTTPFields()
+        headers[HTTPField.Name(forwardedAuthorizationHeader.lowercased())!] =
+            "DPoP forwarded-token"
+        headers[HTTPField.Name(forwardedDPOPHeader.lowercased())!] =
+            "forwarded.dpop.jwt"
+        headers[HTTPField.Name(upstreamDPOPHeader.lowercased())!] =
+            "upstream.dpop.jwt"
+
+        XCTAssertEqual(
+            extractAuthorizationHeader(from: headers),
+            "DPoP forwarded-token"
+        )
+        XCTAssertEqual(extractDPOPHeader(from: headers), "forwarded.dpop.jwt")
+        XCTAssertEqual(extractUpstreamDPOPHeader(from: headers), "upstream.dpop.jwt")
     }
 
     func testAuthExtractorsPreferStandardHeadersOverForwardedProxyHeaders() throws {

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -1,0 +1,135 @@
+import AsyncHTTPClient
+import Crypto
+import Foundation
+import Hummingbird
+@testable import LatrGatewayLib
+import NIOCore
+import XCTest
+
+final class AuthVerificationTests: XCTestCase {
+    func testDPoPRejectsUnsignedProofThatUsedToPassStructureCheck() throws {
+        let token = unsignedAccessToken()
+        let proof = unsignedProof(
+            htm: "GET",
+            htu: "https://api.testing.latr.link/v1/latr/saves",
+            accessToken: token
+        )
+
+        XCTAssertThrowsError(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(path: "/v1/latr/saves")
+            )
+        )
+    }
+
+    func testDPoPRejectsWrongRequestBinding() throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let proof = try signedDPoP(
+            signingKey: key,
+            jwk: jwk,
+            htm: "POST",
+            htu: "https://api.testing.latr.link/v1/latr/saves",
+            accessToken: token
+        )
+
+        XCTAssertThrowsError(
+            try verifyGatewayDPoP(
+                proof: proof,
+                accessToken: token,
+                request: request(path: "/v1/latr/saves")
+            )
+        )
+    }
+
+    func testOAuthVerifierRejectsTamperedAccessTokenSignature() async throws {
+        let key = P256.Signing.PrivateKey()
+        let jwk = jwk(for: key.publicKey)
+        let token = try signedAccessToken(signingKey: key, dpopJWK: jwk)
+        let tampered = "\(token)a"
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    let jwks = #"{"keys":[{"kty":"EC","kid":"test-key","crv":"P-256","x":"\#(jwk.x)","y":"\#(jwk.y)"}]}"#
+                    return Data(jwks.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        do {
+            _ = try await verifier.verify(accessToken: tampered, dpopJWK: jwk)
+            XCTFail("tampered token should fail verification")
+        } catch {}
+        try await httpClient.shutdown()
+    }
+
+    private func request(path: String) -> Request {
+        Request(
+            head: HTTPRequest(
+                method: .get,
+                scheme: "https",
+                authority: "api.testing.latr.link",
+                path: path
+            ),
+            body: RequestBody(buffer: ByteBuffer())
+        )
+    }
+
+    private func unsignedAccessToken() -> String {
+        let header = #"{"alg":"none"}"#
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"test"}}"#
+        return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
+    }
+
+    private func unsignedProof(htm: String, htu: String, accessToken: String) -> String {
+        let header = #"{"typ":"dpop+jwt","alg":"none","jwk":{"kty":"EC","crv":"P-256","x":"test","y":"test"}}"#
+        let ath = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
+        let payload = #"{"htm":"\#(htm)","htu":"\#(htu)","iat":1782860400,"jti":"unsigned-proof","ath":"\#(ath)"}"#
+        return "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8))).sig"
+    }
+
+    private func signedAccessToken(signingKey: P256.Signing.PrivateKey, dpopJWK: DPoPJWK) throws -> String {
+        let header = #"{"alg":"ES256","kid":"test-key"}"#
+        let jkt = try jwkThumbprint(dpopJWK)
+        let payload = #"{"sub":"did:plc:test","iss":"https://auth.example","exp":4102444800,"cnf":{"jkt":"\#(jkt)"}}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func signedDPoP(
+        signingKey: P256.Signing.PrivateKey,
+        jwk: DPoPJWK,
+        htm: String,
+        htu: String,
+        accessToken: String
+    ) throws -> String {
+        let header = #"{"typ":"dpop+jwt","alg":"ES256","jwk":{"kty":"EC","crv":"P-256","x":"\#(jwk.x)","y":"\#(jwk.y)"}}"#
+        let ath = base64URLEncode(Data(SHA256.hash(data: Data(accessToken.utf8))))
+        let payload = #"{"htm":"\#(htm)","htu":"\#(htu)","iat":1782860400,"jti":"\#(UUID().uuidString)","ath":"\#(ath)"}"#
+        return try signJWT(header: header, payload: payload, signingKey: signingKey)
+    }
+
+    private func signJWT(header: String, payload: String, signingKey: P256.Signing.PrivateKey) throws -> String {
+        let signingInput = "\(base64URLEncode(Data(header.utf8))).\(base64URLEncode(Data(payload.utf8)))"
+        let signature = try signingKey.signature(for: Data(signingInput.utf8)).rawRepresentation
+        return "\(signingInput).\(base64URLEncode(signature))"
+    }
+
+    private func jwk(for publicKey: P256.Signing.PublicKey) -> DPoPJWK {
+        let raw = publicKey.x963Representation
+        return DPoPJWK(
+            kty: "EC",
+            crv: "P-256",
+            x: base64URLEncode(raw.dropFirst().prefix(32)),
+            y: base64URLEncode(raw.dropFirst(33).prefix(32))
+        )
+    }
+}

--- a/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/AuthVerificationTests.swift
@@ -220,6 +220,36 @@ final class AuthVerificationTests: XCTestCase {
         let verified = try await verifier.verify(accessToken: token, dpopJWK: dpopJWK)
 
         XCTAssertEqual(verified.payload.sub, "did:plc:test")
+        XCTAssertTrue(verified.signatureVerified)
+        try await httpClient.shutdown()
+    }
+
+    func testOAuthVerifierAcceptsDPoPBoundTokenWhenIssuerJWKSIsEmpty() async throws {
+        let signingKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: Data(hex: "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"),
+            format: .uncompressed
+        )
+        let dpopKey = P256.Signing.PrivateKey()
+        let dpopJWK = jwk(for: dpopKey.publicKey)
+        let token = try signedES256KAccessToken(signingKey: signingKey, dpopJWK: dpopJWK)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
+        let verifier = OAuthTokenVerifier(
+            httpClient: httpClient,
+            fetchData: { url in
+                if url.absoluteString == "https://auth.example/.well-known/oauth-authorization-server" {
+                    return Data(#"{"issuer":"https://auth.example","jwks_uri":"https://auth.example/jwks.json"}"#.utf8)
+                }
+                if url.absoluteString == "https://auth.example/jwks.json" {
+                    return Data(#"{"keys":[]}"#.utf8)
+                }
+                throw GatewayError(status: .unauthorized, message: "unexpected url", code: "test")
+            }
+        )
+
+        let verified = try await verifier.verify(accessToken: token, dpopJWK: dpopJWK)
+
+        XCTAssertEqual(verified.payload.sub, "did:plc:test")
+        XCTAssertFalse(verified.signatureVerified)
         try await httpClient.shutdown()
     }
 

--- a/services/latr-gateway/Tests/LatrGatewayTests/GatewayClientPolicyTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/GatewayClientPolicyTests.swift
@@ -60,4 +60,36 @@ struct GatewayClientPolicyTests {
             resolvesRegisteredClientRequirement(requireClientAPIKey: nil, config: config) == true
         )
     }
+
+    @Test("Token signature verification defaults to prod only")
+    func tokenSignatureVerificationDefaultsToProdOnly() {
+        let dev = GatewayConfig(
+            port: 8080,
+            appEnv: .dev,
+            plcURL: "https://plc.directory",
+            oauthRequireKnownClient: false
+        )
+        let prod = GatewayConfig(
+            port: 8080,
+            appEnv: .prod,
+            plcURL: "https://plc.directory",
+            oauthRequireKnownClient: true
+        )
+
+        #expect(dev.oauthVerifyTokenSignature == false)
+        #expect(prod.oauthVerifyTokenSignature == true)
+    }
+
+    @Test("Token signature verification can be explicitly enabled outside prod")
+    func tokenSignatureVerificationCanBeEnabledOutsideProd() {
+        let config = GatewayConfig(
+            port: 8080,
+            appEnv: .dev,
+            plcURL: "https://plc.directory",
+            oauthRequireKnownClient: false,
+            oauthVerifyTokenSignature: true
+        )
+
+        #expect(config.oauthVerifyTokenSignature == true)
+    }
 }

--- a/services/latr-gateway/Tests/LatrGatewayTests/GatewayClientPolicyTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/GatewayClientPolicyTests.swift
@@ -61,35 +61,4 @@ struct GatewayClientPolicyTests {
         )
     }
 
-    @Test("Token signature verification defaults to prod only")
-    func tokenSignatureVerificationDefaultsToProdOnly() {
-        let dev = GatewayConfig(
-            port: 8080,
-            appEnv: .dev,
-            plcURL: "https://plc.directory",
-            oauthRequireKnownClient: false
-        )
-        let prod = GatewayConfig(
-            port: 8080,
-            appEnv: .prod,
-            plcURL: "https://plc.directory",
-            oauthRequireKnownClient: true
-        )
-
-        #expect(dev.oauthVerifyTokenSignature == false)
-        #expect(prod.oauthVerifyTokenSignature == true)
-    }
-
-    @Test("Token signature verification can be explicitly enabled outside prod")
-    func tokenSignatureVerificationCanBeEnabledOutsideProd() {
-        let config = GatewayConfig(
-            port: 8080,
-            appEnv: .dev,
-            plcURL: "https://plc.directory",
-            oauthRequireKnownClient: false,
-            oauthVerifyTokenSignature: true
-        )
-
-        #expect(config.oauthVerifyTokenSignature == true)
-    }
 }

--- a/services/latr-gateway/Tests/LatrGatewayTests/UpstreamProofPoolTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/UpstreamProofPoolTests.swift
@@ -14,7 +14,8 @@ final class UpstreamProofPoolTests: XCTestCase {
 
         let first = pool.consume(
             forXrpcMethod: "com.atproto.repo.createRecord",
-            httpMethod: "POST"
+            httpMethod: "POST",
+            pdsBase: "https://pds.example"
         )
         XCTAssertEqual(first?.proof, createOne)
         XCTAssertEqual(
@@ -24,20 +25,37 @@ final class UpstreamProofPoolTests: XCTestCase {
 
         let second = pool.consume(
             forXrpcMethod: "com.atproto.repo.createRecord",
-            httpMethod: "POST"
+            httpMethod: "POST",
+            pdsBase: "https://pds.example"
         )
         XCTAssertEqual(second?.proof, createTwo)
 
         let third = pool.consume(
             forXrpcMethod: "com.atproto.repo.putRecord",
-            httpMethod: "POST"
+            httpMethod: "POST",
+            pdsBase: "https://pds.example"
         )
         XCTAssertEqual(third?.proof, putProof)
 
         XCTAssertNil(
             pool.consume(
                 forXrpcMethod: "com.atproto.repo.createRecord",
-                httpMethod: "POST"
+                httpMethod: "POST",
+                pdsBase: "https://pds.example"
+            )
+        )
+    }
+
+    func testRejectsMatchingMethodOnDifferentPDSOrigin() {
+        let proof =
+            "eyJhbGciOiJub25lIn0.eyJodHUiOiJodHRwczovL2F0dGFja2VyLmV4YW1wbGUveHJwYy9jb20uYXRwcm90by5yZXBvLmNyZWF0ZVJlY29yZCIsImh0bSI6IlBPU1QifQ.signature"
+        let pool = UpstreamProofPool(rawHeader: proof)
+
+        XCTAssertNil(
+            pool.consume(
+                forXrpcMethod: "com.atproto.repo.createRecord",
+                httpMethod: "POST",
+                pdsBase: "https://pds.example"
             )
         )
     }


### PR DESCRIPTION
## Summary

Promotes the gateway OAuth/DPoP production fixes from `dev` to `main` so hosted L@tr saves can work with current ATProto OAuth tokens and same-origin web proxy requests.

This includes the LTR-2 production unblock and related LTR-6 ES256K work:

- supports ATProto OAuth access tokens signed with `ES256K` / secp256k1 when issuer keys are published
- handles the current `bsky.social` empty-JWKS behavior without requiring users to reissue tokens
- keeps gateway-bound DPoP verification strict for method, URL, access-token hash, signature, and replay checks
- accepts same-origin proxy URL bindings forwarded through the web app proxy
- keeps L@tr gateway client credentials server-side in the Next.js proxy
- constrains weaker empty-JWKS token handling to PDS-backed save/read/write routes where the PDS remains the final OAuth authority
- requires locally verified token signatures for developer and non-PDS utility routes
- uses authenticated PDS `getRecord` for saved-item lookup when local token signature verification is unavailable

## Why

Testing showed two separate production blockers:

1. Browser requests through `/api/latr-gateway/*` could fail DPoP URL validation if the gateway only considered the upstream Fly URL instead of the browser-minted same-origin URL.
2. Current bsky.social access tokens use `alg: ES256K`, while `https://bsky.social/oauth/jwks` currently returns an empty key set. Reissuing user tokens does not fix that, so PDS-backed routes need to rely on the PDS as the authoritative OAuth verifier while preserving local DPoP binding checks.

## Validation

- Confirmed hosted save/list flows are now working properly after the gateway changes.
- Added/updated gateway auth tests covering ES256K, tampered token rejection, missing DPoP confirmation, unsupported algorithms, and empty-JWKS behavior.
- Verified local diff hygiene with `git diff --check` before the feature PR was merged.
- Local full Swift test execution was limited by local sandbox/toolchain issues, so GitHub CI remains the authoritative verification path for this promotion.

## Rollout Notes

- Users should not need to issue new tokens for this fix.
- After merge, confirm the production gateway deploy completes and retest hosted save/list/archive/delete flows.
- The same implementation notes were documented on The Social Wire issue TSW-8 because its saved-link integration needs the analogous proxy and gateway-auth behavior.