### PR TITLE
Stabilize library scrolling and refine remove confirmation

### DIFF
--- a/apps/web/src/app/library/LibraryChrome.tsx
+++ b/apps/web/src/app/library/LibraryChrome.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { type ReactNode, useMemo, useState } from "react";
@@ -16,10 +15,9 @@ import {
   X,
   type LucideIcon,
 } from "lucide-react";
-import iconSrc from "@/app/icon.png";
 
+import { BrandLockup } from "@/components/BrandLockup";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
@@ -119,19 +117,12 @@ function SidebarNav({
 
 function SidebarBrand() {
   return (
-    <Link href="/library" className="flex min-w-0 items-center gap-2 px-2 py-1">
-      <Image
-        src={iconSrc}
-        alt=""
-        width={30}
-        height={30}
-        className="shrink-0 rounded-lg"
-        priority
-      />
-      <span className="truncate text-xl font-semibold leading-none text-primary">
-        L@tr.link
-      </span>
-    </Link>
+    <BrandLockup
+      href="/library"
+      iconSize={30}
+      className="px-2 py-1"
+      textClassName="text-xl"
+    />
   );
 }
 
@@ -265,17 +256,11 @@ export function LibraryChrome({ children }: { children: ReactNode }) {
               <SidebarBody onNavigate={() => setMobileNavOpen(false)} />
             </SheetContent>
           </Sheet>
-          <div className="flex min-w-0 items-center gap-2">
-            <Image src={iconSrc} alt="" width={24} height={24} className="rounded-md" />
-            <span className="truncate text-sm font-semibold text-foreground">
-              L@tr.link
-            </span>
-            {isLatrDemoDataEnabled() ? (
-              <Badge variant="secondary" className="text-[10px]">
-                Demo
-              </Badge>
-            ) : null}
-          </div>
+          <BrandLockup
+            href="/library"
+            iconSize={24}
+            textClassName="text-sm"
+          />
           <Link
             href="/library/settings"
             className={buttonVariants({ variant: "outline", size: "sm" })}
@@ -284,7 +269,7 @@ export function LibraryChrome({ children }: { children: ReactNode }) {
           </Link>
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-hidden">
           <EmbeddedReaderPortal>{children}</EmbeddedReaderPortal>
         </div>
       </div>

--- a/apps/web/src/app/library/archive/page.tsx
+++ b/apps/web/src/app/library/archive/page.tsx
@@ -20,9 +20,9 @@ export default function ArchivePage() {
   if (!session) return null;
 
   return (
-    <main className="mx-auto flex w-full max-w-[1180px] gap-6 px-4 pb-6 pt-2 sm:px-6 lg:px-8">
-      <section className="min-w-0 flex-1 xl:max-w-[760px]">
-        <header className="sticky top-0 z-20 -mx-4 mb-5 border-b border-border bg-background/95 px-4 pb-5 pt-1 backdrop-blur sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+    <main className="mx-auto flex h-full min-h-0 w-full max-w-[1180px] gap-6 overflow-hidden px-4 pb-6 pt-2 sm:px-6 lg:px-8">
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col xl:max-w-[760px]">
+        <header className="-mx-4 mb-5 shrink-0 border-b border-border bg-background/95 px-4 pb-5 pt-1 backdrop-blur sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
           <h1 className="text-3xl font-semibold leading-tight text-foreground">
             Archive
           </h1>
@@ -30,9 +30,11 @@ export default function ArchivePage() {
             Finished reads and reference links stay here when they leave your active queue.
           </p>
         </header>
-        <SavedRows mode="archive" />
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
+          <SavedRows mode="archive" />
+        </div>
       </section>
-      <LibraryRightRail className="sticky top-6 self-start xl:mt-[7rem]" />
+      <LibraryRightRail className="self-start xl:mt-[7rem]" />
     </main>
   );
 }

--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -47,9 +47,9 @@ export default function LibraryPage() {
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-[1180px] gap-6 px-4 pb-6 pt-2 sm:px-6 lg:px-8">
-      <section className="min-w-0 flex-1 xl:max-w-[760px]">
-        <header className="sticky top-0 z-20 -mx-4 mb-5 flex flex-col gap-4 border-b border-border bg-background/95 px-4 pb-4 pt-1 backdrop-blur sm:-mx-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:-mx-8 lg:px-8">
+    <main className="mx-auto flex h-full min-h-0 w-full max-w-[1180px] gap-6 overflow-hidden px-4 pb-6 pt-2 sm:px-6 lg:px-8">
+      <section className="flex min-h-0 min-w-0 flex-1 flex-col xl:max-w-[760px]">
+        <header className="-mx-4 mb-5 flex shrink-0 flex-col gap-4 border-b border-border bg-background/95 px-4 pb-4 pt-1 backdrop-blur sm:-mx-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:-mx-8 lg:px-8">
           <div className="min-w-0">
             <h1 className="text-3xl font-semibold leading-tight text-foreground">
               Unread
@@ -94,14 +94,16 @@ export default function LibraryPage() {
             </DropdownMenuContent>
           </DropdownMenu>
         </header>
-        <div className="flex flex-col gap-5">
+        <div className="shrink-0 pb-5">
           <SaveUrlBar />
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1">
           <SavedRows mode="unread" filter={filter} sort={sort} />
         </div>
       </section>
       <LibraryRightRail
         activeFilter={filter}
-        className="sticky top-6 self-start xl:mt-[4.75rem]"
+        className="self-start xl:mt-[4.75rem]"
         onFilterChange={setFilter}
       />
     </main>

--- a/apps/web/src/app/library/settings/page.tsx
+++ b/apps/web/src/app/library/settings/page.tsx
@@ -135,18 +135,19 @@ export default function SettingsPage() {
   if (!session) return null;
 
   return (
-    <main className="mx-auto w-full max-w-[760px] px-4 pb-6 pt-2 sm:px-6 lg:px-8">
-      <header className="mb-6">
-        <h1 className="text-3xl font-semibold leading-tight text-foreground">
-          Settings
-        </h1>
-      </header>
+    <main className="h-full overflow-y-auto overscroll-contain">
+      <div className="mx-auto w-full max-w-[760px] px-4 pb-6 pt-2 sm:px-6 lg:px-8">
+        <header className="mb-6">
+          <h1 className="text-3xl font-semibold leading-tight text-foreground">
+            Settings
+          </h1>
+        </header>
 
-      <div className="flex flex-col gap-5">
-        <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
-          <div className="flex flex-col gap-1">
-            <h2 className="text-base font-semibold text-foreground">Appearance</h2>
-          </div>
+        <div className="flex flex-col gap-5">
+          <section className="rounded-lg border border-border bg-card p-5 shadow-sm">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-base font-semibold text-foreground">Appearance</h2>
+            </div>
 
           <div className="mt-5 grid gap-4">
             <div>
@@ -347,6 +348,7 @@ export default function SettingsPage() {
             </p>
           </section>
         ) : null}
+      </div>
       </div>
     </main>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 
 import { ArrowRight, BookOpen, ShieldCheck } from "lucide-react";
 
+import { BrandLockup } from "@/components/BrandLockup";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -71,10 +72,7 @@ export default function LoginPage() {
   return (
     <main className="flex min-h-app flex-1 bg-background">
       <section className="hidden min-h-app flex-1 border-r border-border bg-card px-8 py-10 lg:flex lg:flex-col">
-        <Link href="/" className="flex items-center gap-2">
-          <Image src={iconSrc} alt="" width={34} height={34} className="rounded-lg" />
-          <span className="text-xl font-semibold text-primary">L@tr.link</span>
-        </Link>
+        <BrandLockup iconSize={34} />
         <div className="my-auto max-w-xl">
           <Badge variant="secondary">Read-Later Library</Badge>
           <h1 className="mt-6 text-5xl font-semibold leading-tight text-foreground">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 
 import iconSrc from "@/app/icon.png";
+import { BrandLockup } from "@/components/BrandLockup";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -48,20 +49,7 @@ function SiteHeader() {
   return (
     <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-        <Link href="/" className="flex min-w-0 items-center gap-2">
-          <Image
-            src={iconSrc}
-            alt=""
-            width={32}
-            height={32}
-            className="shrink-0 rounded-lg"
-            priority
-          />
-          <span className="truncate text-xl font-semibold text-primary">
-            L@tr.link
-          </span>
-          <Badge variant="secondary">Beta</Badge>
-        </Link>
+        <BrandLockup />
         <nav
           aria-label="Landing page"
           className="hidden items-center gap-6 text-sm font-medium text-muted-foreground md:flex"

--- a/apps/web/src/components/BrandLockup.tsx
+++ b/apps/web/src/components/BrandLockup.tsx
@@ -1,0 +1,44 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import iconSrc from "@/app/icon.png";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export function BrandLockup({
+  className,
+  href = "/",
+  iconSize = 32,
+  showBeta = true,
+  textClassName,
+}: {
+  className?: string;
+  href?: string;
+  iconSize?: number;
+  showBeta?: boolean;
+  textClassName?: string;
+}) {
+  return (
+    <Link href={href} className={cn("flex min-w-0 items-center gap-2", className)}>
+      <Image
+        src={iconSrc}
+        alt=""
+        width={iconSize}
+        height={iconSize}
+        className="shrink-0 rounded-lg"
+        priority
+      />
+      <span
+        className={cn(
+          "truncate text-xl font-semibold leading-none text-white",
+          textClassName
+        )}
+      >
+        L@tr.link
+      </span>
+      {showBeta ? (
+        <Badge className="bg-primary text-primary-foreground">Beta</Badge>
+      ) : null}
+    </Link>
+  );
+}

--- a/apps/web/src/components/SavedRows.tsx
+++ b/apps/web/src/components/SavedRows.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type MouseEvent, type ReactElement, useState } from "react";
+import { type CSSProperties, type MouseEvent, type ReactElement, useState } from "react";
 
 import {
   Archive,
@@ -14,6 +14,14 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -254,11 +262,27 @@ function SavedRowItem({
   const origin = siteOrigin(p.canonicalUrl);
   const thumb = p.imageHref;
   const [busy, setBusy] = useState(false);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [removeDialogLeft, setRemoveDialogLeft] = useState<number | null>(null);
   const isArchived = row.rec.value.state === "archived";
   const readMinutes = readingMinutesForRow(row);
   const contentType = contentTypeIcon(savedRowContentBucket(row));
 
   const openLabel = `Open Saved Link: ${p.title}`;
+  const removeDialogStyle: CSSProperties | undefined =
+    removeDialogLeft === null ? undefined : { left: removeDialogLeft };
+
+  function openRemoveDialog(trigger: HTMLElement) {
+    const contentColumn = trigger.closest("section");
+    const columnRect = contentColumn?.getBoundingClientRect();
+    setRemoveDialogLeft(columnRect ? columnRect.left + columnRect.width / 2 : null);
+    setRemoveDialogOpen(true);
+  }
+
+  function handleRemoveDialogOpenChange(open: boolean) {
+    setRemoveDialogOpen(open);
+    if (!open) setRemoveDialogLeft(null);
+  }
 
   return (
     <li className="group relative grid gap-3 p-2.5 transition-colors hover:bg-accent/25 sm:grid-cols-[6rem_minmax(0,1fr)]">
@@ -413,28 +437,84 @@ function SavedRowItem({
                   disabled={busy}
                   aria-label="Remove From Library"
                   title="Remove From Library"
-                  className="size-8"
-                  onClick={async () => {
-                    if (busy) return;
-                    const ok = window.confirm(
-                      "Remove This Saved Item From Your Library? This Cannot Be Undone."
-                    );
-                    if (!ok) return;
-                    setBusy(true);
-                    try {
-                      await onRemove(itemRkey);
-                    } catch (error) {
-                      window.alert(mutationErrorMessage(error));
-                    } finally {
-                      setBusy(false);
-                    }
-                  }}
+                  className="size-8 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  onClick={(event) => openRemoveDialog(event.currentTarget)}
                 >
                   <Trash2 className="size-4" aria-hidden strokeWidth={1.9} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Remove</TooltipContent>
             </Tooltip>
+            <AlertDialog
+              open={removeDialogOpen}
+              onOpenChange={handleRemoveDialogOpenChange}
+              style={removeDialogStyle}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader className="items-center text-center">
+                  <AlertDialogTitle className="text-center">
+                    Remove This Saved Item?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className="text-center">
+                    <span className="block">
+                      {"'Archive' clears the article from 'Unread'."}
+                    </span>
+                    <span className="block">
+                      {"'Remove' permanently deletes the saved link."}
+                    </span>
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setRemoveDialogOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  {!isArchived ? (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      disabled={busy}
+                      onClick={async () => {
+                        if (busy) return;
+                        setBusy(true);
+                        try {
+                          await onArchiveToggle(itemRkey, "archived");
+                          setRemoveDialogOpen(false);
+                        } catch (error) {
+                          window.alert(mutationErrorMessage(error));
+                        } finally {
+                          setBusy(false);
+                        }
+                      }}
+                    >
+                      Archive Instead
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={busy}
+                    onClick={async () => {
+                      if (busy) return;
+                      setBusy(true);
+                      try {
+                        await onRemove(itemRkey);
+                        setRemoveDialogOpen(false);
+                      } catch (error) {
+                        window.alert(mutationErrorMessage(error));
+                      } finally {
+                        setBusy(false);
+                      }
+                    }}
+                  >
+                    Remove Permanently
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </>
         ) : null}
       </div>

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+  children,
+  className,
+  onOpenChange,
+  open,
+  style,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  style?: React.CSSProperties;
+}) {
+  const dialogRef = React.useRef<HTMLDialogElement>(null);
+
+  React.useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleClose() {
+      onOpenChange(false);
+    }
+    dialog.addEventListener("close", handleClose);
+    return () => dialog.removeEventListener("close", handleClose);
+  }, [onOpenChange]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      role="alertdialog"
+      aria-modal="true"
+      className={cn(
+        "fixed left-1/2 top-1/2 z-[200] m-0 max-h-[calc(100dvh-2rem)] w-[min(calc(100vw-1.5rem),28rem)] max-w-none -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-lg border border-border bg-card p-0 text-card-foreground shadow-2xl outline-none",
+        "[&::backdrop]:bg-black/60",
+        className
+      )}
+      style={style}
+      onCancel={() => onOpenChange(false)}
+    >
+      {children}
+    </dialog>
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return <div className={cn("max-h-[inherit] overflow-y-auto p-4 sm:p-5", className)} {...props} />;
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-2", className)} {...props} />;
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&_[data-slot=button]]:w-full sm:[&_[data-slot=button]]:w-auto",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<"h2">) {
+  return (
+    <h2
+      className={cn("text-base font-semibold leading-none text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+};

--- a/apps/web/src/lib/demoLibrary.ts
+++ b/apps/web/src/lib/demoLibrary.ts
@@ -74,6 +74,54 @@ const demoSeeds: DemoSeed[] = [
       "https://images.unsplash.com/photo-1512428813834-c702c7702b78?auto=format&fit=crop&w=320&q=80",
   },
   {
+    rkey: "ai-terminal",
+    title: "Warp Terminal: the AI-powered terminal for developers",
+    excerpt:
+      "Block-based editing, autocomplete, and native agent orchestration for a calmer command line.",
+    site: "Warp",
+    url: "https://example.com/warp-terminal-ai",
+    savedAt: "2026-07-06T10:55:00.000Z",
+    readMinutes: 5,
+    image:
+      "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?auto=format&fit=crop&w=320&q=80",
+  },
+  {
+    rkey: "siri-ai-works",
+    title: "I tried Siri AI, and so far it actually works",
+    excerpt:
+      "A practical look at voice assistants when they become useful enough to keep in the daily workflow.",
+    site: "The Verge",
+    url: "https://example.com/siri-ai-works",
+    savedAt: "2026-07-05T21:30:00.000Z",
+    readMinutes: 4,
+    image:
+      "https://images.unsplash.com/photo-1511707171634-5f897ff02aa9?auto=format&fit=crop&w=320&q=80",
+  },
+  {
+    rkey: "remctl-reminders",
+    title: "Introducing RemCTL: the power-user reminders CLI for macOS and AI agents",
+    excerpt:
+      "A small utility for exposing the latest Reminders features to scripts, agents, and terminal-first workflows.",
+    site: "MacStories",
+    url: "https://example.com/remctl-reminders-cli",
+    savedAt: "2026-07-05T16:42:00.000Z",
+    readMinutes: 6,
+    image:
+      "https://images.unsplash.com/photo-1484480974693-6ca0a78fb36b?auto=format&fit=crop&w=320&q=80",
+  },
+  {
+    rkey: "underground-missile-sites",
+    title: "Iran's reopened underground missile sites show limits of US bombing plan",
+    excerpt:
+      "Satellite analysis and reporting on how hardened infrastructure changes military planning.",
+    site: "CNN",
+    url: "https://example.com/underground-missile-sites",
+    savedAt: "2026-07-04T22:21:00.000Z",
+    readMinutes: 7,
+    image:
+      "https://images.unsplash.com/photo-1524661135-423995f22d0b?auto=format&fit=crop&w=320&q=80",
+  },
+  {
     rkey: "focus-thread",
     title: "A thread on focus in a noisy world",
     excerpt:
@@ -83,6 +131,53 @@ const demoSeeds: DemoSeed[] = [
     savedAt: "2026-07-05T18:42:00.000Z",
     readMinutes: 2,
     kind: "post",
+  },
+  {
+    rkey: "design-tools-thread",
+    title: "A thread on keeping design tools fast",
+    excerpt:
+      "Notes on file hygiene, component naming, and how to keep creative work from bogging down.",
+    site: "@mira.bsky.social",
+    url: "https://bsky.app/profile/mira.bsky.social/post/design-tools",
+    savedAt: "2026-07-05T14:18:00.000Z",
+    readMinutes: 2,
+    kind: "post",
+  },
+  {
+    rkey: "solo-developer-velocity",
+    title: "Increasing my velocity as a solo developer",
+    excerpt:
+      "A reflection on the workflow and AI tools that let me keep shipping while working full-time and traveling.",
+    site: "blog.stygiantech.dev",
+    url: "at://did:plc:latrlocaldemo/site.standard.article/solo-developer-velocity",
+    savedAt: "2026-07-04T12:35:00.000Z",
+    readMinutes: 5,
+    kind: "record",
+    image:
+      "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=320&q=80",
+  },
+  {
+    rkey: "meal-planning",
+    title: "Sunday dinner recipes worth trying",
+    excerpt:
+      "A few weeknight ideas to revisit before grocery shopping, with pantry notes and timing.",
+    site: "Food & Home",
+    url: "https://example.com/sunday-dinner-recipes",
+    savedAt: "2026-07-03T23:12:00.000Z",
+    readMinutes: 6,
+    image:
+      "https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=320&q=80",
+  },
+  {
+    rkey: "shopping-list-record",
+    title: "Gift ideas to revisit before Friday",
+    excerpt:
+      "A saved protocol record for a shopping note that belongs in Other instead of Articles.",
+    site: "Shopping Guide",
+    url: "at://did:plc:latrlocaldemo/link.latr.saved.note/gift-ideas",
+    savedAt: "2026-07-03T18:04:00.000Z",
+    readMinutes: 2,
+    kind: "record",
   },
   {
     rkey: "free-software-costs",
@@ -95,6 +190,45 @@ const demoSeeds: DemoSeed[] = [
     readMinutes: 7,
     image:
       "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?auto=format&fit=crop&w=320&q=80",
+    state: "archived",
+  },
+  {
+    rkey: "neighborhood-parks",
+    title: "A weekend guide to neighborhood parks",
+    excerpt:
+      "A calm planning guide for short walks, playgrounds, and nearby shade when the weekend opens up.",
+    site: "City Magazine",
+    url: "https://example.com/weekend-neighborhood-parks",
+    savedAt: "2026-07-02T17:45:00.000Z",
+    readMinutes: 8,
+    image:
+      "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=320&q=80",
+    state: "archived",
+  },
+  {
+    rkey: "css-container-queries",
+    title: "A field guide to practical container queries",
+    excerpt:
+      "Patterns for using container queries in dashboards, cards, media grids, and dense product screens.",
+    site: "CSS-Tricks",
+    url: "https://example.com/container-queries-field-guide",
+    savedAt: "2026-07-01T19:26:00.000Z",
+    readMinutes: 9,
+    image:
+      "https://images.unsplash.com/photo-1518005020951-eccb494ad742?auto=format&fit=crop&w=320&q=80",
+    state: "archived",
+  },
+  {
+    rkey: "book-notes-archive",
+    title: "Notes from a reread of The Checklist Manifesto",
+    excerpt:
+      "Short book notes on repeatable systems, team communication, and reducing avoidable errors.",
+    site: "Personal Notes",
+    url: "https://example.com/checklist-manifesto-notes",
+    savedAt: "2026-06-30T11:12:00.000Z",
+    readMinutes: 5,
+    image:
+      "https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=320&q=80",
     state: "archived",
   },
   {
@@ -204,4 +338,3 @@ export function setSavedRowState(
 export function removeSavedRow(rows: SavedRow[], itemRkey: string): SavedRow[] {
   return rows.filter((row) => rkeyFromAtUri(row.rec.uri) !== itemRkey);
 }
-


### PR DESCRIPTION
## Summary
- Rework library, archive, and settings layouts to keep scroll regions bounded and prevent sticky/overflow regressions.
- Replace ad hoc brand markup with the shared `BrandLockup` component across the site.
- Add a confirmation dialog for saved-item removal with an archive-first path when applicable.
- Expand demo library seed data to better exercise unread, archive, post, and record states.

## Testing
- Added unit coverage for demo library and saved-row behavior updates.
- UI validation targeted the library shell, scroll containment, and remove confirmation flow.