### PR TITLE
Reduce OAuth scopes for extension and web clients

### DIFF
--- a/apps/web/public/client-metadata.json
+++ b/apps/web/public/client-metadata.json
@@ -4,9 +4,10 @@
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
   "redirect_uris": ["https://latr.link/callback"],
-  "scope": "atproto repo:link.latr.saved.external?action=create&action=update&action=delete repo:link.latr.saved.item?action=create&action=update&action=delete repo:com.latr.saved.external?action=create&action=update&action=delete repo:com.latr.saved.item?action=create&action=update&action=delete",
+  "scope": "atproto repo:link.latr.saved.external?action=create&action=update repo:link.latr.saved.item?action=create&action=update&action=delete repo:com.latr.saved.external?action=delete repo:com.latr.saved.item?action=delete",
   "token_endpoint_auth_method": "none",
   "dpop_bound_access_tokens": true,
   "client_name": "L@tr.link",
-  "client_uri": "https://latr.link"
+  "client_uri": "https://latr.link",
+  "logo_uri": "https://latr.link/icon.png"
 }

--- a/apps/web/public/extension/client-metadata.json
+++ b/apps/web/public/extension/client-metadata.json
@@ -4,11 +4,12 @@
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
   "redirect_uris": ["https://latr.link/extension/callback"],
-  "scope": "atproto repo:link.latr.saved.external?action=create&action=update&action=delete repo:link.latr.saved.item?action=create&action=update&action=delete repo:com.latr.saved.external?action=create&action=update&action=delete repo:com.latr.saved.item?action=create&action=update&action=delete",
+  "scope": "atproto repo:link.latr.saved.external?action=create&action=update repo:link.latr.saved.item?action=create&action=update&action=delete repo:com.latr.saved.external?action=delete repo:com.latr.saved.item?action=delete",
   "token_endpoint_auth_method": "none",
   "dpop_bound_access_tokens": true,
   "client_name": "L@tr.link Extension",
   "client_uri": "https://latr.link",
+  "logo_uri": "https://latr.link/icon.png",
   "software_id": "latr-extension",
   "software_version": "0.1.0"
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -160,6 +160,29 @@ export default function LoginPage() {
                 <ArrowRight className="size-4" aria-hidden strokeWidth={2} />
               </Button>
             </form>
+
+            {!demoMode ? (
+              <details className="mt-5 border-t border-border pt-4 text-sm">
+                <summary className="cursor-pointer font-medium text-foreground">
+                  What L@tr.link can access
+                </summary>
+                <div className="mt-3 space-y-2 leading-5 text-muted-foreground">
+                  <p>
+                    L@tr.link can identify your account and create or update
+                    link metadata in your public repository.
+                  </p>
+                  <p>
+                    It can create, update, and delete only your L@tr saved-item
+                    records. It can also delete obsolete L@tr records after a
+                    one-time migration.
+                  </p>
+                  <p>
+                    It cannot post for you, edit your profile, read messages or
+                    email, upload media, or manage your account.
+                  </p>
+                </div>
+              </details>
+            ) : null}
           </div>
           <p className="mt-4 text-center text-xs text-muted-foreground">
             New here?{" "}

--- a/apps/web/src/lib/oauthClientMetadata.test.ts
+++ b/apps/web/src/lib/oauthClientMetadata.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { AT_PROTO_OAUTH_SCOPES } from "@/lib/atprotoOAuthScopes";
 import {
@@ -20,6 +22,31 @@ describe("Buildweboauthclientmetadata", () => {
       "https://preview.example.vercel.app/callback",
     ]);
     expect(metadata.scope).toBe(AT_PROTO_OAUTH_SCOPES);
+    expect(metadata.logo_uri).toBe(
+      "https://preview.example.vercel.app/icon.png"
+    );
+  });
+});
+
+describe("static OAuth client metadata", () => {
+  test("keeps web and extension documents on the shared minimal scopes", () => {
+    const web = JSON.parse(
+      readFileSync(
+        resolve(import.meta.dir, "../../public/client-metadata.json"),
+        "utf8"
+      )
+    ) as { scope: string; logo_uri: string };
+    const extension = JSON.parse(
+      readFileSync(
+        resolve(import.meta.dir, "../../public/extension/client-metadata.json"),
+        "utf8"
+      )
+    ) as { scope: string; logo_uri: string };
+
+    expect(web.scope).toBe(AT_PROTO_OAUTH_SCOPES);
+    expect(extension.scope).toBe(AT_PROTO_OAUTH_SCOPES);
+    expect(web.logo_uri).toBe("https://latr.link/icon.png");
+    expect(extension.logo_uri).toBe("https://latr.link/icon.png");
   });
 });
 

--- a/apps/web/src/lib/oauthClientMetadata.ts
+++ b/apps/web/src/lib/oauthClientMetadata.ts
@@ -53,5 +53,6 @@ export function buildWebOAuthClientMetadata(origin: string) {
     dpop_bound_access_tokens: true,
     client_name: "L@tr.link",
     client_uri: base,
+    logo_uri: `${base}/icon.png`,
   } as const;
 }

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -40,6 +40,12 @@ Save, list, archive, and unsave run through the L@tr gateway. The web app no lon
 
 ## OAuth scopes
 
-Repository writes require explicit `repo:` scopes for both collections, aligned with `apps/web/public/client-metadata.json`. Users must re-auth after scope changes.
+Repository writes use action-limited `repo:` scopes aligned across the shared web client, hosted metadata, and Swift gateway metadata:
+
+- `link.latr.saved.external`: create and update wrapper metadata.
+- `link.latr.saved.item`: create, update, and delete saved queue entries.
+- Legacy `com.latr.saved.*`: delete only, after the one-time copy into current collections.
+
+Public repository reads require no additional permission. L@tr.link does not request profile, post, blob, message, email, or account-management access. Users must re-auth after scope changes.
 
 See [latr-gateway.md](./latr-gateway.md) for route contracts, deployment, and auth constraints.

--- a/packages/latr-web-client/src/atprotoOAuthScopes.test.ts
+++ b/packages/latr-web-client/src/atprotoOAuthScopes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { LATR_ATPROTO_OAUTH_SCOPES } from "./atprotoOAuthScopes";
+
+describe("LATR_ATPROTO_OAUTH_SCOPES", () => {
+  test("requests only the repository mutations used by L@tr", () => {
+    expect(LATR_ATPROTO_OAUTH_SCOPES).toEqual([
+      "atproto",
+      "repo:link.latr.saved.external?action=create&action=update",
+      "repo:link.latr.saved.item?action=create&action=update&action=delete",
+      "repo:com.latr.saved.external?action=delete",
+      "repo:com.latr.saved.item?action=delete",
+    ]);
+  });
+});

--- a/packages/latr-web-client/src/atprotoOAuthScopes.ts
+++ b/packages/latr-web-client/src/atprotoOAuthScopes.ts
@@ -1,7 +1,32 @@
-import { LATR_REPO_OAUTH_SCOPES } from "latr-packages/gateway-client";
+import {
+  COLLECTION_SAVED_EXTERNAL,
+  COLLECTION_SAVED_ITEM,
+  LEGACY_COLLECTION_SAVED_EXTERNAL,
+  LEGACY_COLLECTION_SAVED_ITEM,
+} from "latr-packages/gateway-client";
 
-/** OAuth scopes for L@tr repo collections (current + legacy cleanup). */
-export const LATR_ATPROTO_OAUTH_SCOPES = ["atproto", ...LATR_REPO_OAUTH_SCOPES] as const;
+function repoScope(
+  collection: string,
+  actions: readonly ("create" | "update" | "delete")[]
+): string {
+  const query = actions.map((action) => `action=${action}`).join("&");
+  return `repo:${collection}?${query}`;
+}
+
+/**
+ * Exact repository mutations used by L@tr.link.
+ *
+ * Public repository reads need no additional permission. Legacy collections are
+ * read during one-time migration, but L@tr only needs permission to delete them
+ * after copying their records into the current collections.
+ */
+export const LATR_ATPROTO_OAUTH_SCOPES = [
+  "atproto",
+  repoScope(COLLECTION_SAVED_EXTERNAL, ["create", "update"]),
+  repoScope(COLLECTION_SAVED_ITEM, ["create", "update", "delete"]),
+  repoScope(LEGACY_COLLECTION_SAVED_EXTERNAL, ["delete"]),
+  repoScope(LEGACY_COLLECTION_SAVED_ITEM, ["delete"]),
+] as const;
 
 /** @deprecated Use {@link LATR_ATPROTO_OAUTH_SCOPES} */
 export const AT_PROTO_OAUTH_SCOPES = LATR_ATPROTO_OAUTH_SCOPES.join(" ");

--- a/services/latr-gateway/Sources/LatrGatewayLib/OAuth/ATProtoOAuthScopes.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/OAuth/ATProtoOAuthScopes.swift
@@ -1,12 +1,13 @@
 import Foundation
 
-/// OAuth scopes for L@tr.link web clients. Keep aligned with `apps/web/public/client-metadata.json`.
+/// Exact repository mutations used by L@tr.link web and extension clients.
+/// Keep aligned with `packages/latr-web-client/src/atprotoOAuthScopes.ts`.
 public enum ATProtoOAuthScopes {
     public static let scope = [
         "atproto",
-        "repo:link.latr.saved.external?action=create&action=update&action=delete",
+        "repo:link.latr.saved.external?action=create&action=update",
         "repo:link.latr.saved.item?action=create&action=update&action=delete",
-        "repo:com.latr.saved.external?action=create&action=update&action=delete",
-        "repo:com.latr.saved.item?action=create&action=update&action=delete",
+        "repo:com.latr.saved.external?action=delete",
+        "repo:com.latr.saved.item?action=delete",
     ].joined(separator: " ")
 }

--- a/services/latr-gateway/Sources/LatrGatewayLib/OAuth/ExtensionOAuthClientMetadata.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/OAuth/ExtensionOAuthClientMetadata.swift
@@ -31,6 +31,7 @@ public enum ExtensionOAuthClientMetadata {
             let dpop_bound_access_tokens: Bool
             let client_name: String
             let client_uri: String
+            let logo_uri: String
             let software_id: String
         }
 
@@ -45,6 +46,7 @@ public enum ExtensionOAuthClientMetadata {
             dpop_bound_access_tokens: true,
             client_name: "L@tr.link Extension",
             client_uri: redirectBase,
+            logo_uri: "\(redirectBase)/icon.png",
             software_id: "latr-extension"
         )
         let encoder = JSONEncoder()

--- a/services/latr-gateway/Sources/LatrGatewayLib/OAuth/WebOAuthClientMetadata.swift
+++ b/services/latr-gateway/Sources/LatrGatewayLib/OAuth/WebOAuthClientMetadata.swift
@@ -39,6 +39,7 @@ public enum WebOAuthClientMetadata {
             let dpop_bound_access_tokens: Bool
             let client_name: String
             let client_uri: String
+            let logo_uri: String
         }
 
         let doc = MetadataBody(
@@ -51,7 +52,8 @@ public enum WebOAuthClientMetadata {
             token_endpoint_auth_method: "none",
             dpop_bound_access_tokens: true,
             client_name: "L@tr.link",
-            client_uri: metadataBase
+            client_uri: redirectBase,
+            logo_uri: "\(redirectBase)/icon.png"
         )
         let enc = JSONEncoder()
         enc.outputFormatting = [.sortedKeys]

--- a/services/latr-gateway/Tests/LatrGatewayTests/ExtensionOAuthClientMetadataTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/ExtensionOAuthClientMetadataTests.swift
@@ -21,6 +21,7 @@ final class ExtensionOAuthClientMetadataTests: XCTestCase {
         )
         XCTAssertEqual(object["scope"] as? String, ATProtoOAuthScopes.scope)
         XCTAssertEqual(object["client_uri"] as? String, "https://testing.latr.link")
+        XCTAssertEqual(object["logo_uri"] as? String, "https://testing.latr.link/icon.png")
         XCTAssertEqual(object["software_id"] as? String, "latr-extension")
     }
 }

--- a/services/latr-gateway/Tests/LatrGatewayTests/WebOAuthClientMetadataTests.swift
+++ b/services/latr-gateway/Tests/LatrGatewayTests/WebOAuthClientMetadataTests.swift
@@ -3,6 +3,17 @@ import LatrGatewayLib
 import XCTest
 
 final class WebOAuthClientMetadataTests: XCTestCase {
+    func testOAuthScopesMatchTheExactRepositoryMutations() {
+        XCTAssertEqual(
+            ATProtoOAuthScopes.scope,
+            "atproto "
+                + "repo:link.latr.saved.external?action=create&action=update "
+                + "repo:link.latr.saved.item?action=create&action=update&action=delete "
+                + "repo:com.latr.saved.external?action=delete "
+                + "repo:com.latr.saved.item?action=delete"
+        )
+    }
+
     func testBuildsGatewayMetadataWithSeparateRedirectOrigin() throws {
         let data = try WebOAuthClientMetadata.buildJSON(
             publicOrigin: "https://latr-link-dev-gateway.fly.dev",
@@ -18,5 +29,7 @@ final class WebOAuthClientMetadataTests: XCTestCase {
             ["https://testing.latr.link/callback"]
         )
         XCTAssertEqual(obj?["scope"] as? String, ATProtoOAuthScopes.scope)
+        XCTAssertEqual(obj?["client_uri"] as? String, "https://testing.latr.link")
+        XCTAssertEqual(obj?["logo_uri"] as? String, "https://testing.latr.link/icon.png")
     }
 }


### PR DESCRIPTION
## Summary
- Narrow ATProto OAuth scopes for the extension and web clients to the minimum required permissions.
- Update client metadata, callback handling, and auth flow code across web, extension, gateway, and shared packages to keep scope definitions aligned.
- Refresh docs and tests to cover the new scope contract and metadata generation behavior.

## Testing
- Added and updated unit tests for scope helpers, OAuth metadata, pending-save flow, and gateway metadata routes.
- Verified the affected client and gateway paths with focused test coverage for the new minimal-scope behavior.