### PR TITLE
fix: install gateway curl runtime

### DIFF
--- a/services/latr-gateway/Dockerfile
+++ b/services/latr-gateway/Dockerfile
@@ -12,7 +12,7 @@ RUN swift build -c release --static-swift-stdlib
 FROM ubuntu:22.04
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates postgresql-client \
+    && apt-get install -y --no-install-recommends ca-certificates libcurl4 postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /src/services/latr-gateway/.build/release/LatrGateway /usr/local/bin/latr-gateway


### PR DESCRIPTION
## What changed
Installs `libcurl4` in the gateway runtime image.

## Why
Railway's XRPC deployment built successfully but the new replica could not start because `libcurl.so.4` was absent.

## Verification
- built the full gateway Docker image locally
- `ldd /usr/local/bin/latr-gateway` resolves libcurl, libssl, and libcrypto with no missing libraries

## Rollout
Development Railway only; production remains untouched.