### PR TITLE
fix: recover library from stale bookmark cache

### DIFF
--- a/apps/web/src/app/library/settings/page.tsx
+++ b/apps/web/src/app/library/settings/page.tsx
@@ -21,6 +21,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useLatrRepo } from "@/hooks/useLatrRepo";
 import { useTheme } from "@/hooks/useTheme";
 import { isLatrDemoDataEnabled } from "@/lib/demoMode";
+import { clearPersistedQueryCache } from "@/lib/queryPersistence";
 import {
   fontLabel,
   themeLabel,
@@ -323,7 +324,7 @@ export default function SettingsPage() {
             variant="outline"
             onClick={() => {
               try {
-                localStorage.removeItem("latr.link.react-query.v1");
+                clearPersistedQueryCache(localStorage);
                 setMessage("Cleared Local React Query Cache.");
               } catch {
                 setMessage("Could Not Clear Storage.");

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -10,8 +10,8 @@ import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persist
 import { AuthProvider } from "@/hooks/useAuth";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { syncLatrGatewayFromBrowser } from "@/lib/latrGatewayUrl";
+import { QUERY_PERSIST_KEY } from "@/lib/queryPersistence";
 
-const QUERY_PERSIST_KEY = "latr.link.react-query.v2";
 const QUERY_PERSIST_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 7;
 
 function shouldDehydrateQuery(query: Query): boolean {

--- a/apps/web/src/components/SavedRows.test.ts
+++ b/apps/web/src/components/SavedRows.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, test } from "bun:test";
 
 import { createDemoSavedRows } from "@/lib/demoLibrary";
-import { sortSavedRows } from "./SavedRows";
+import { savedAtShort, sortSavedRows } from "./SavedRows";
+
+describe("Saved Row Dates", () => {
+  test("Formats A Valid Created Time", () => {
+    expect(savedAtShort("2026-08-14T12:00:00.000Z")).toBe("Aug 14, 2026");
+  });
+
+  test("Handles A Persisted Pre-Migration Row Without Created Time", () => {
+    expect(savedAtShort(undefined)).toBe("Date unavailable");
+  });
+
+  test("Falls Back Safely For An Invalid Created Time", () => {
+    expect(savedAtShort("not-a-date")).toBe("not-a-date");
+  });
+});
 
 describe("Saved Rows Sorting", () => {
   test("Sorts Archive Rows by Archived Time Before Saved Time", () => {

--- a/apps/web/src/components/SavedRows.tsx
+++ b/apps/web/src/components/SavedRows.tsx
@@ -97,7 +97,9 @@ function faviconUrlForOrigin(origin: string): string {
   return `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(origin)}`;
 }
 
-function savedAtShort(iso: string): string {
+export function savedAtShort(iso: string | null | undefined): string {
+  if (!iso) return "Date unavailable";
+
   try {
     return new Intl.DateTimeFormat("en-US", {
       month: "short",

--- a/apps/web/src/lib/queryPersistence.test.ts
+++ b/apps/web/src/lib/queryPersistence.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  clearPersistedQueryCache,
+  QUERY_PERSIST_KEY,
+} from "./queryPersistence";
+
+describe("Persisted Query Cache", () => {
+  test("Uses A New Cache Version For The Bookmark Schema Migration", () => {
+    expect(QUERY_PERSIST_KEY).toBe("latr.link.react-query.v3");
+  });
+
+  test("Clears Current And Legacy Cache Versions", () => {
+    const removed: string[] = [];
+    const storage = {
+      removeItem(key: string) {
+        removed.push(key);
+      },
+    } as Storage;
+
+    clearPersistedQueryCache(storage);
+
+    expect(removed).toEqual([
+      "latr.link.react-query.v1",
+      "latr.link.react-query.v2",
+      "latr.link.react-query.v3",
+    ]);
+  });
+});

--- a/apps/web/src/lib/queryPersistence.ts
+++ b/apps/web/src/lib/queryPersistence.ts
@@ -1,0 +1,12 @@
+export const QUERY_PERSIST_KEY = "latr.link.react-query.v3";
+
+const LEGACY_QUERY_PERSIST_KEYS = [
+  "latr.link.react-query.v1",
+  "latr.link.react-query.v2",
+] as const;
+
+export function clearPersistedQueryCache(storage: Storage): void {
+  for (const key of [...LEGACY_QUERY_PERSIST_KEYS, QUERY_PERSIST_KEY]) {
+    storage.removeItem(key);
+  }
+}


### PR DESCRIPTION
## What changed

- Rotate the persisted React Query cache key after the bookmark record schema migration.
- Render a safe fallback when a cached row has no `createdAt`.
- Clear all known persisted cache versions from Library Settings.
- Add regression tests for legacy rows and cache invalidation.

## Why

Production clients can still hydrate v2 cache entries created before the XRPC/Lexicon migration. Those rows contain `savedAt` rather than `createdAt`, causing `/library` to call `.slice()` on `undefined` and show the global error boundary.

## Verification

- `bash scripts/ci.sh`
- Web tests: 111 passed.
- Web lint and TypeScript passed.
- Production Next.js build passed.

## Risk

Low. Existing v2 browser cache is ignored and repopulated from the user's PDS; PDS records are unchanged.

Linear: LTR-14
