### PR TITLE
fix(web): add contextual browser titles

### DIFF
--- a/apps/web/src/app/callback/layout.tsx
+++ b/apps/web/src/app/callback/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Signing In",
+};
+
+export default function CallbackLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/extension/callback/layout.tsx
+++ b/apps/web/src/app/extension/callback/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Extension Sign In",
+};
+
+export default function ExtensionCallbackLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/library/archive/layout.tsx
+++ b/apps/web/src/app/library/archive/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Archive",
+};
+
+export default function ArchiveLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/library/layout.tsx
+++ b/apps/web/src/app/library/layout.tsx
@@ -1,4 +1,13 @@
+import type { Metadata } from "next";
+
 import { LibraryChrome } from "./LibraryChrome";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Library",
+    template: "%s · L@tr.link",
+  },
+};
 
 export default function LibraryLayout({
   children,

--- a/apps/web/src/app/library/settings/layout.tsx
+++ b/apps/web/src/app/library/settings/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
+
+export default function SettingsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/login/layout.tsx
+++ b/apps/web/src/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+};
+
+export default function LoginLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/routeTitles.test.ts
+++ b/apps/web/src/app/routeTitles.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { metadata as callbackMetadata } from "./callback/layout";
+import { metadata as extensionCallbackMetadata } from "./extension/callback/layout";
+import { metadata as libraryMetadata } from "./library/layout";
+import { metadata as archiveMetadata } from "./library/archive/layout";
+import { metadata as settingsMetadata } from "./library/settings/layout";
+import { metadata as loginMetadata } from "./login/layout";
+
+describe("route title metadata", () => {
+  test("preserves the site title template for nested library routes", () => {
+    expect(libraryMetadata.title).toEqual({
+      default: "Library",
+      template: "%s · L@tr.link",
+    });
+  });
+
+  test.each([
+    ["/login", loginMetadata, "Sign In"],
+    ["/callback", callbackMetadata, "Signing In"],
+    ["/extension/callback", extensionCallbackMetadata, "Extension Sign In"],
+    ["/library/archive", archiveMetadata, "Archive"],
+    ["/library/settings", settingsMetadata, "Settings"],
+  ])("defines a contextual title for %s", (_route, metadata, expectedTitle) => {
+    expect(metadata.title).toBe(expectedTitle);
+  });
+});


### PR DESCRIPTION
## What changed
- add server-side route metadata for Sign In, OAuth callbacks, Library, Archive, and Settings
- preserve the L@tr.link title template through nested library routes
- add a metadata contract test for every contextual route

## Why
Browser tabs previously inherited the generic site title, making authentication and library views difficult to distinguish.

## Testing
- Bun 1.3.14 focused route title test: 6 passed
- Bun 1.3.14 full web suite: 125 passed
- web typecheck
- web lint with zero warnings
- Next.js 16.2.6 production build
- production-server raw HTML check: exactly one expected title on all seven user-facing routes

## Risk
Low. The change uses static Server Component metadata and does not alter page rendering, authentication, or client bundles.

Linear: LTR-17