### PR TITLE
fix(web): add contextual browser titles

### DIFF
--- a/apps/web/src/app/callback/layout.tsx
+++ b/apps/web/src/app/callback/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Signing In",
+};
+
+export default function CallbackLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/extension/callback/layout.tsx
+++ b/apps/web/src/app/extension/callback/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Extension Sign In",
+};
+
+export default function ExtensionCallbackLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/library/archive/layout.tsx
+++ b/apps/web/src/app/library/archive/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Archive",
+};
+
+export default function ArchiveLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/library/layout.tsx
+++ b/apps/web/src/app/library/layout.tsx
@@ -1,4 +1,13 @@
+import type { Metadata } from "next";
+
 import { LibraryChrome } from "./LibraryChrome";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Library",
+    template: "%s · L@tr.link",
+  },
+};
 
 export default function LibraryLayout({
   children,

--- a/apps/web/src/app/library/settings/layout.tsx
+++ b/apps/web/src/app/library/settings/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
+
+export default function SettingsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/login/layout.tsx
+++ b/apps/web/src/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+};
+
+export default function LoginLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/apps/web/src/app/routeTitles.test.ts
+++ b/apps/web/src/app/routeTitles.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { metadata as callbackMetadata } from "./callback/layout";
+import { metadata as extensionCallbackMetadata } from "./extension/callback/layout";
+import { metadata as libraryMetadata } from "./library/layout";
+import { metadata as archiveMetadata } from "./library/archive/layout";
+import { metadata as settingsMetadata } from "./library/settings/layout";
+import { metadata as loginMetadata } from "./login/layout";
+
+describe("route title metadata", () => {
+  test("preserves the site title template for nested library routes", () => {
+    expect(libraryMetadata.title).toEqual({
+      default: "Library",
+      template: "%s · L@tr.link",
+    });
+  });
+
+  test.each([
+    ["/login", loginMetadata, "Sign In"],
+    ["/callback", callbackMetadata, "Signing In"],
+    ["/extension/callback", extensionCallbackMetadata, "Extension Sign In"],
+    ["/library/archive", archiveMetadata, "Archive"],
+    ["/library/settings", settingsMetadata, "Settings"],
+  ])("defines a contextual title for %s", (_route, metadata, expectedTitle) => {
+    expect(metadata.title).toBe(expectedTitle);
+  });
+});


### PR DESCRIPTION
## Summary

Promotes the LTR-17 contextual browser-title implementation that has already merged to and deployed successfully in Development.

## Development evidence

- Development merge: `6877a628350f10e0a81fbf899eb620a4880d3cf2`
- Railway Web deployment succeeded
- All seven required routes emitted exactly one expected SSR `<title>`
- Web tests, lint, typecheck, build, and required GitHub CI passed

## Production

This PR changes route metadata only. No runtime configuration or social metadata changes are included.